### PR TITLE
add insecure flag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
-sed -i "s/#####HF_SERVER#####/$HF_SERVER/g" /usr/share/nginx/html/main*.*.js
+
+# check all args for the insecure flag
+if [[ "$@" == *"--insecure"* ]]; then
+    HF_SERVER=http://$HF_SERVER
+else
+    HF_SERVER=https://$HF_SERVER
+fi
+
+sed -i "s|#####HF_SERVER#####|$HF_SERVER|g;" /usr/share/nginx/html/main*.*.js
+
 echo "Configured with HF_SERVER=$HF_SERVER"
+
 nginx -g 'daemon off;' # overriding nginx default startup

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -34,7 +34,7 @@ export class LoginComponent {
             .set("password", this.password)
             .set("access_code", this.accesscode);
 
-        this.http.post('https://' + environment.server + "/auth/registerwithaccesscode", body)
+        this.http.post(environment.server + "/auth/registerwithaccesscode", body)
             .subscribe(
                 (s: ServerResponse) => {
                     this.success = "Success! User created. Please login.";
@@ -58,7 +58,7 @@ export class LoginComponent {
             .set("email", this.email)
             .set("password", this.password);
 
-        this.http.post('https://' + environment.server + "/auth/authenticate", body)
+        this.http.post(environment.server + "/auth/authenticate", body)
             .subscribe(
                 (s: ServerResponse) => {
                     // should have a token here

--- a/src/app/scenario/scenariocard.component.ts
+++ b/src/app/scenario/scenariocard.component.ts
@@ -25,7 +25,7 @@ export class ScenarioCard implements OnInit {
 
     ngOnInit() {
         this.error = "";
-        this.http.get('https://' + environment.server + "/scenario/" + this.scenarioid)
+        this.http.get(environment.server + "/scenario/" + this.scenarioid)
         .subscribe(
             (s: ServerResponse) => {
                 this.scenario = JSON.parse(atob(s.content));

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -318,7 +318,7 @@ export class StepComponent implements OnInit, DoCheck {
     }
 
     actuallyFinish() {
-        this.http.put('https://' + environment.server + "/session/" + this.route.snapshot.paramMap.get("scenariosession") + "/finished", {})
+        this.http.put(environment.server + "/session/" + this.route.snapshot.paramMap.get("scenariosession") + "/finished", {})
             .subscribe(
                 (s: ServerResponse) => {
                     this.router.navigateByUrl("/app/home");
@@ -340,7 +340,7 @@ export class StepComponent implements OnInit, DoCheck {
                     this.pauseModal.open();
                 },
                 (s: ServerResponse) => {
-                    // failure! what now? 
+                    // failure! what now?
                 }
             )
     }

--- a/src/app/scenario/terminal.component.ts
+++ b/src/app/scenario/terminal.component.ts
@@ -50,7 +50,12 @@ export class TerminalComponent implements OnChanges {
             this.term = new Terminal();
 
 
-            this.socket = new WebSocket("wss://" + this.endpoint + "/shell/" + this.vmid + "/connect?auth=" + this.jwtHelper.tokenGetter());
+            if (environment.server.startsWith("https")) {
+                this.endpoint = "wss://" + this.endpoint
+            } else {
+                this.endpoint = "ws://" + this.endpoint
+            }
+            this.socket = new WebSocket(this.endpoint + "/shell/" + this.vmid + "/connect?auth=" + this.jwtHelper.tokenGetter());
 
             this.socket.onopen = (e) => {
                 this.term.attach(this.socket, true, true);

--- a/src/app/services/scenario.service.ts
+++ b/src/app/services/scenario.service.ts
@@ -17,7 +17,7 @@ export class ScenarioService {
     }
 
     public list() {
-        return this.http.get('https://' + environment.server + '/scenario/list')
+        return this.http.get(environment.server + '/scenario/list')
             .pipe(
                 map((s: ServerResponse) => {
                     return JSON.parse(atob(s.content));
@@ -34,7 +34,7 @@ export class ScenarioService {
         if (this.cachedScenarios.get(id) != null) {
             return of(this.cachedScenarios.get(id));
         } else {
-            return this.http.get('https://' + environment.server + '/scenario/' + id)
+            return this.http.get(environment.server + '/scenario/' + id)
                 .pipe(
                     map((s: ServerResponse) => {
                         return JSON.parse(atob(s.content));

--- a/src/app/services/scenariosession.service.ts
+++ b/src/app/services/scenariosession.service.ts
@@ -18,7 +18,7 @@ export class ScenarioSessionService {
     public new(sessionId: string) {
         let params = new HttpParams()
             .set("scenario", sessionId);
-        return this.http.post('https://' + environment.server + "/session/new", params)
+        return this.http.post(environment.server + "/session/new", params)
             .pipe(
                 map((s: ServerResponse) => {
                     return JSON.parse(atob(s.content));
@@ -30,15 +30,15 @@ export class ScenarioSessionService {
     }
 
     public pause(sessionId: string) {
-        return this.http.put("https://" + environment.server + '/session/' + sessionId + '/pause', {});
+        return this.http.put(environment.server + '/session/' + sessionId + '/pause', {});
     }
 
     public resume(sessionId: string) {
-        return this.http.put("https://" + environment.server + '/session/' + sessionId + '/resume', {});
+        return this.http.put(environment.server + '/session/' + sessionId + '/resume', {});
     }
 
     public keepalive(sessionId: string) {
-        return this.http.put('https://' + environment.server + '/session/' + sessionId + '/keepalive', {})
+        return this.http.put(environment.server + '/session/' + sessionId + '/keepalive', {})
     }
 
     public get(id: string) {
@@ -46,9 +46,9 @@ export class ScenarioSessionService {
             return of(this.cachedScenarioSessions.get(id));
             // HOW DO WE MAKE THIS EXPIRE?
         } else {
-            return this.http.get('https://' + environment.server + "/session/" + id)
+            return this.http.get(environment.server + "/session/" + id)
                 .pipe(
-                    // do a "map and tap" 
+                    // do a "map and tap"
                     map((s: ServerResponse) => {
                         return JSON.parse(atob(s.content));
                     }),

--- a/src/app/services/step.service.ts
+++ b/src/app/services/step.service.ts
@@ -20,7 +20,7 @@ export class StepService {
         if (this.cachedSteps.get(scenario + ":" + index) != null)  {
             return of(this.cachedSteps.get(scenario  + ":" + index));
         } else {
-            return this.http.get('https://' + environment.server + '/scenario/' + scenario + '/step/' + index)
+            return this.http.get(environment.server + '/scenario/' + scenario + '/step/' + index)
             .pipe(
                 map((s: ServerResponse) => {
                     return JSON.parse(atob(s.content));

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -24,7 +24,7 @@ export class UserService {
     .set("old_password", oldPassword)
     .set("new_password", newPassword);
 
-    return this.http.post<ServerResponse>("https://" + environment.server + "/auth/changepassword", params)
+    return this.http.post<ServerResponse>(environment.server + "/auth/changepassword", params)
     .pipe(
       catchError((e: HttpErrorResponse) => {
         return throwError(e.error);
@@ -33,7 +33,7 @@ export class UserService {
   }
 
   public getAccessCodes() {
-    return this.http.get("https://" + environment.server + "/auth/accesscode")
+    return this.http.get(environment.server + "/auth/accesscode")
     .pipe(
       switchMap((s: ServerResponse) => {
         return of(JSON.parse(atob(s.content)))
@@ -48,22 +48,22 @@ export class UserService {
     var params = new HttpParams()
     .set("access_code", a);
     this._acModified.next(true);
-    return this.http.post<ServerResponse>("https://" + environment.server + "/auth/accesscode", params)
-    .pipe(
-      catchError((e: HttpErrorResponse) => {
-        return throwError(e.error);
-      })
-    ) 
-  }
-
-  public deleteAccessCode(a: string) {
-    this._acModified.next(true);
-    return this.http.delete<ServerResponse>("https://" + environment.server + "/auth/accesscode/" + a)
+    return this.http.post<ServerResponse>(environment.server + "/auth/accesscode", params)
     .pipe(
       catchError((e: HttpErrorResponse) => {
         return throwError(e.error);
       })
     )
   }
-  
+
+  public deleteAccessCode(a: string) {
+    this._acModified.next(true);
+    return this.http.delete<ServerResponse>(environment.server + "/auth/accesscode/" + a)
+    .pipe(
+      catchError((e: HttpErrorResponse) => {
+        return throwError(e.error);
+      })
+    )
+  }
+
 }

--- a/src/app/services/vm.service.ts
+++ b/src/app/services/vm.service.ts
@@ -14,7 +14,7 @@ export class VMService {
     ) { }
 
     public get(id: string) {
-        return this.http.get('https://' + environment.server + '/vm/' + id)
+        return this.http.get(environment.server + '/vm/' + id)
             .pipe(
                 map((s: ServerResponse) => {
                     return JSON.parse(atob(s.content));

--- a/src/app/services/vmclaim.service.ts
+++ b/src/app/services/vmclaim.service.ts
@@ -16,7 +16,7 @@ export class VMClaimService {
     }
 
     public get(id: string): Observable<VMClaim> {
-        return this.http.get('https://' + environment.server + '/vmclaim/' + id)
+        return this.http.get(environment.server + '/vmclaim/' + id)
             .pipe(
                 map((s: ServerResponse) => {
                     var v = JSON.parse(atob(s.content));


### PR DESCRIPTION
This adds an `--insecure` flag that will prepend `http://` (and `ws://`) to the backend endpoints. For parity, these changes also prepend the secure versions (`https://` and `wss://`) by default.