### PR TITLE
Fix insecure runtime configuration

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -77,10 +77,10 @@ const appInitializerFn = (appConfig: AppConfigService) => {
       config: {
         tokenGetter: tokenGetter,
         whitelistedDomains: [
-          environment.server
+          environment.server.match(/.*\:\/\/?([^\/]+)/)[1]
         ],
         blacklistedRoutes: [
-          environment.server + "/auth/authenticate"
+          environment.server.match(/.*\:\/\/?([^\/]+)/)[1] + "/auth/authenticate"
         ],
         skipWhenExpired: true
       }

--- a/src/app/scenario/terminal.component.ts
+++ b/src/app/scenario/terminal.component.ts
@@ -6,6 +6,7 @@ import { JwtHelperService } from '@auth0/angular-jwt';
 import { CtrService } from './ctr.service';
 import { CodeExec } from './CodeExec';
 import { ShellService } from '../services/shell.service';
+import { environment } from 'src/environments/environment';
 
 @Component({
     selector: 'terminal',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@ import pkg from '../../package.json';
 
 export const environment = {
   production: false,
-  server: "api.na1dev.hobbyfarm.io",
+  server: "https://api.na1dev.hobbyfarm.io",
   version: pkg.version
 };
 


### PR DESCRIPTION
Auth0's JWT helper requires an FQDN (*not* URL) to configure whitelisting and blacklisting for injecting auth token into requests. 

Because of the runtime changes, one needs to now pass http(s):// in the environment.server value, which was causing JwtModule to choke.

This PR fixes that issue, by specifying a regex to ignore everything pre-:// (roughly speaking just extracting the fqdn from a url). 

It also includes a fix where terminal.component.ts was missing a reference to environment file