### PR TITLE
add course object

### DIFF
--- a/src/app/Session.ts
+++ b/src/app/Session.ts
@@ -1,6 +1,7 @@
-export class ScenarioSession {
+export class Session {
     id: string;
     scenario: string;
+    course: string;
     user: string;
     vm_claim: string[];
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -24,7 +24,11 @@ const routes: Routes = [
         component: ScenarioComponent
       },
       {
-        path: 'session/:scenariosession/steps/:step',
+        path: 'course/:course/scenario/:scenario',
+        component: ScenarioComponent
+      },
+      {
+        path: 'session/:session/steps/:step',
         component: StepComponent
       },
       {path: 'terminal', component: TerminalComponent}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,7 +26,8 @@ import { VMInfoComponent } from './scenario/vminfo.component';
 import { CtrService } from './scenario/ctr.service';
 import { VMInfoService } from './scenario/vminfo.service';
 import { ScenarioService } from './services/scenario.service';
-import { ScenarioSessionService } from './services/scenariosession.service';
+import { CourseService } from './services/course.service';
+import { SessionService } from './services/session.service';
 import { StepService } from './services/step.service';
 import { VMService } from './services/vm.service';
 import { VMClaimService } from './services/vmclaim.service';
@@ -91,8 +92,9 @@ const appInitializerFn = (appConfig: AppConfigService) => {
     AuthGuard,
     CtrService,
     VMInfoService,
+    CourseService,
     ScenarioService,
-    ScenarioSessionService,
+    SessionService,
     StepService,
     VMService,
     VMClaimService,

--- a/src/app/course/course.ts
+++ b/src/app/course/course.ts
@@ -1,0 +1,9 @@
+import { Scenario } from '../scenario/Scenario';
+
+export class Course {
+    id: string;
+    name: string;
+    description: string;
+    scenarioCount: number;
+    scenarios: Scenario[];
+}

--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -15,7 +15,7 @@
     </div>
 
     <ng-container *ngIf="scenarios?.length > 0">
-      <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3 clr-col-xl" *ngFor="let s of scenarios">
+      <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3" *ngFor="let s of scenarios">
         <scenario-card [(scenarioid)]="s.id" (scenarioModal)="toggleScenarioModal($event)"></scenario-card>
       </div>
     </ng-container>
@@ -33,7 +33,7 @@
 
         <div class="clr-row">
           <ng-container *ngIf="c.scenarios?.length > 0; else no_scenarios">
-            <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3 clr-col-xl" *ngFor="let s of c?.scenarios">
+            <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3" *ngFor="let s of c?.scenarios">
               <scenario-card [(scenarioid)]="s" [(courseid)]="c.id" (scenarioModal)="toggleScenarioModal($event)">
               </scenario-card>
             </div>

--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -15,7 +15,7 @@
     </div>
 
     <ng-container *ngIf="scenarios?.length > 0">
-      <div class="clr-col-3" *ngFor="let s of scenarios">
+      <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3 clr-col-xl" *ngFor="let s of scenarios">
         <scenario-card [(scenarioid)]="s.id" (scenarioModal)="toggleScenarioModal($event)"></scenario-card>
       </div>
     </ng-container>

--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -1,19 +1,55 @@
-<div class="clr-row">
+<div class="content-area">
+
+  <div class="clr-row">
     <div class="clr-col">
-        <h3>Select a scenario</h3>
+      <h1>Select a scenario</h1>
     </div>
-</div>
-<div class="clr-row">
+  </div>
+
+  <div class="clr-row">
+
+    <div class="clr-col-12">
+      <div *ngIf="!courses && !scenarios">
+        No scenarios or courses found.
+      </div>
+    </div>
+
     <ng-container *ngIf="scenarios?.length > 0">
-        <div class="clr-col-3" *ngFor="let s of scenarios">
-            <scenario-card [(scenarioid)]="s.id"></scenario-card>
-        </div>
+      <div class="clr-col-3" *ngFor="let s of scenarios">
+        <scenario-card [(scenarioid)]="s.id" (scenarioModal)="toggleScenarioModal($event)"></scenario-card>
+      </div>
     </ng-container>
-    <ng-container *ngIf="scenarios?.length <= 0">
-        <div class="clr-col-12">
-            <p>
-                No scenarios found. 
-            </p>
+  </div>
+
+  <div class="clr-row">
+    <div class="clr-col-12">
+      <ng-container *ngFor="let c of courses">
+        <h2 class="course-header">{{ c.id }} - {{ c.name | atob }}</h2>
+        <span *ngIf="c.inProgress">
+          <button class="btn btn-info-outline">Complete</button>
+        </span>
+        <hr />
+        <p class="course-description">{{ c.description | atob }}</p>
+
+        <div class="clr-row">
+          <ng-container *ngIf="c.scenarios?.length > 0; else no_scenarios">
+            <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3 clr-col-xl" *ngFor="let s of c?.scenarios">
+              <scenario-card [(scenarioid)]="s" [(courseid)]="c.id" (scenarioModal)="toggleScenarioModal($event)">
+              </scenario-card>
+            </div>
+          </ng-container>
+          <ng-template #no_scenarios>
+            <div class="clr-col-12">
+              <p>
+                No scenarios found.
+              </p>
+            </div>
+          </ng-template>
         </div>
-    </ng-container>
-</div>
+
+      </ng-container>
+    </div>
+  </div>
+
+
+  </div>

--- a/src/app/home.component.scss
+++ b/src/app/home.component.scss
@@ -1,0 +1,7 @@
+#course-list-title {
+  font-size: 150%;
+}
+
+.course-description {
+  font-size: 0.75rem;
+}

--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -3,29 +3,39 @@ import { JwtHelperService } from '@auth0/angular-jwt';
 import { HttpClient } from '@angular/common/http';
 import { ServerResponse } from './ServerResponse';
 import { Scenario } from './scenario/Scenario';
+import { Course } from './course/course';
 import { environment } from 'src/environments/environment';
 import { UserService } from './services/user.service';
+import { CourseService } from './services/course.service';
 import { ScenarioService } from './services/scenario.service';
 
 @Component({
     selector: 'home-component',
-    templateUrl: 'home.component.html'
+    templateUrl: 'home.component.html',
+    styleUrls: ['home.component.scss']
 })
 
 export class HomeComponent implements OnInit {
+    public courses: Course[] = [];
     public scenarios: Scenario[] = [];
     constructor(
         public helper: JwtHelperService,
         public http: HttpClient,
         public userService: UserService,
-        public scenarioService: ScenarioService
+        public scenarioService: ScenarioService,
+        public courseService: CourseService
     ) {
     }
 
     _refresh() {
+        this.courseService.list().subscribe(
+            (c: Course[]) => {
+                this.courses = c;
+            }
+        )
         this.scenarioService.list().subscribe(
             (s: Scenario[]) => {
-                this.scenarios = s
+                this.scenarios = s;
             }
         )
     }

--- a/src/app/scenario/scenariocard.component.ts
+++ b/src/app/scenario/scenariocard.component.ts
@@ -13,6 +13,8 @@ import { environment } from 'src/environments/environment';
 export class ScenarioCard implements OnInit {
     @Input()
     public scenarioid: string = "";
+    @Input()
+    public courseid: string = "";
 
     public scenario: Scenario = new Scenario();
     public error: string = "";
@@ -37,6 +39,10 @@ export class ScenarioCard implements OnInit {
     }
 
     navScenario() {
-        this.router.navigateByUrl("/app/scenario/" + this.scenarioid)
+        if (this.courseid) {
+            this.router.navigateByUrl("/app/course/" + this.courseid + "/scenario/" + this.scenarioid)
+        } else {
+            this.router.navigateByUrl("/app/scenario/" + this.scenarioid)
+        }
     }
 }

--- a/src/app/scenario/vminfo.component.ts
+++ b/src/app/scenario/vminfo.component.ts
@@ -2,9 +2,9 @@ import { Component } from '@angular/core';
 import { OnMount } from '../dynamic-html';
 import { VM } from '../VM';
 import { delay, retryWhen, switchMap, concatMap, filter } from 'rxjs/operators';
-import { ScenarioSessionService } from '../services/scenariosession.service';
+import { SessionService } from '../services/session.service';
 import { VMClaimService } from '../services/vmclaim.service';
-import { ScenarioSession } from '../ScenarioSession';
+import { Session } from '../Session';
 import { from, of, Observable } from 'rxjs';
 import { VMClaim } from '../VMClaim';
 import { VMClaimVM } from '../VMClaimVM';
@@ -31,7 +31,7 @@ export class VMInfoComponent implements OnMount {
     public vm: VM = new VM();
 
     constructor(
-        public ssService: ScenarioSessionService,
+        public ssService: SessionService,
         public vmClaimService: VMClaimService,
         public vmService: VMService,
         public vmInfoService: VMInfoService
@@ -57,7 +57,7 @@ export class VMInfoComponent implements OnMount {
                         delay(3000)
                     )
                 }),
-                switchMap((s: ScenarioSession) => {
+                switchMap((s: Session) => {
                     return from(s.vm_claim);
                 }),
                 concatMap((claimid: string) => {

--- a/src/app/services/course.service.ts
+++ b/src/app/services/course.service.ts
@@ -22,6 +22,7 @@ export class CourseService {
             return JSON.parse(atob(s.content));
         }),
         tap((c: Course[]) => {
+            if (!c) { return; }
             c.forEach((t: Course) => {
                 this.cachedCourses.set(t.id, t);
             })

--- a/src/app/services/course.service.ts
+++ b/src/app/services/course.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams, HttpParameterCodec } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
+import { ServerResponse } from '../ServerResponse';
+import { map, tap } from 'rxjs/operators';
+import { Scenario } from '../scenario/Scenario';
+import { Course } from '../course/course';
+import { of } from 'rxjs';
+
+@Injectable()
+export class CourseService {
+  private cachedCourses: Map<string, Course> = new Map();
+
+  constructor(
+    public http: HttpClient
+  ) { }
+
+  public list() {
+    return this.http.get(environment.server + "/course/list")
+      .pipe(
+        map((s: ServerResponse) => {
+            return JSON.parse(atob(s.content));
+        }),
+        tap((c: Course[]) => {
+            c.forEach((t: Course) => {
+                this.cachedCourses.set(t.id, t);
+            })
+        })
+      )
+  }
+
+  public get(id: string) {
+    if (this.cachedCourses.get(id) != null) {
+        return of(this.cachedCourses.get(id));
+    } else {
+        return this.http.get(environment.server + '/course/' + id)
+            .pipe(
+                map((s: ServerResponse) => {
+                    return JSON.parse(atob(s.content));
+                }),
+                tap((c: Course) => {
+                    this.cachedCourses.set(c.id, c);
+                })
+            )
+    }
+  }
+}

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,29 +1,31 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
-import { ScenarioSession } from '../ScenarioSession';
+import { Session } from '../Session';
+import { Course } from '../course/course';
 import { of } from 'rxjs';
 import { tap, map, repeatWhen, delay } from 'rxjs/operators';
 import { ServerResponse } from '../ServerResponse';
 import { environment } from 'src/environments/environment';
 
 @Injectable()
-export class ScenarioSessionService {
-    private cachedScenarioSessions: Map<string, ScenarioSession> = new Map();
+export class SessionService {
+    private cachedScenarioSessions: Map<string, Session> = new Map();
 
     constructor(
         private http: HttpClient
     ) {
     }
 
-    public new(sessionId: string) {
+    public new(sessionId: string, courseId: string) {
         let params = new HttpParams()
-            .set("scenario", sessionId);
+            .set("scenario", sessionId)
+            .set("course", courseId);
         return this.http.post(environment.server + "/session/new", params)
             .pipe(
                 map((s: ServerResponse) => {
                     return JSON.parse(atob(s.content));
                 }),
-                tap((s: ScenarioSession) => {
+                tap((s: Session) => {
                     this.cachedScenarioSessions.set(s.id, s);
                 })
             )
@@ -52,7 +54,7 @@ export class ScenarioSessionService {
                     map((s: ServerResponse) => {
                         return JSON.parse(atob(s.content));
                     }),
-                    tap((s: ScenarioSession) => {
+                    tap((s: Session) => {
                         this.cachedScenarioSessions.set(s.id, s);
                     })
                 )

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -18,8 +18,10 @@ export class SessionService {
 
     public new(sessionId: string, courseId: string) {
         let params = new HttpParams()
-            .set("scenario", sessionId)
-            .set("course", courseId);
+            .set("scenario", sessionId);
+            if (courseId) {
+                params.set("course", courseId);
+            }
         return this.http.post(environment.server + "/session/new", params)
             .pipe(
                 map((s: ServerResponse) => {


### PR DESCRIPTION
These changes add a `course` object which is a collection of `scenarios`. Additionally, it renames `scenariosession` to `session`. VMs should persist over a `session`, which is the `course` if it exists and a `scenario` otherwise.