### PR TITLE
full terminal and sidebar

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -26,13 +26,20 @@
             ],
             "styles": [
               "node_modules/@clr/icons/clr-icons.min.css",
-              "node_modules/xterm/dist/xterm.css",
-              "src/styles.scss"
+              "node_modules/xterm/css/xterm.css",
+              "src/styles.scss",
+              "node_modules/prismjs/themes/prism.css"
             ],
             "scripts": [
               "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
-              "node_modules/xterm/dist/xterm.js",
-              "node_modules/marked/lib/marked.js"
+              "node_modules/xterm/lib/xterm.js",
+              "node_modules/marked/lib/marked.js",
+              "node_modules/prismjs/prism.js",
+              "node_modules/prismjs/components/prism-yaml.min.js",
+              "node_modules/prismjs/components/prism-python.min.js",
+              "node_modules/prismjs/components/prism-go.min.js",
+              "node_modules/prismjs/components/prism-docker.min.js",
+              "node_modules/prismjs/components/prism-json.min.js"
             ],
             "es5BrowserSupport": true
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12964,9 +12964,19 @@
       "dev": true
     },
     "xterm": {
-      "version": "3.14.5",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.14.5.tgz",
-      "integrity": "sha512-DVmQ8jlEtL+WbBKUZuMxHMBgK/yeIZwkXB81bH+MGaKKnJGYwA+770hzhXPfwEIokK9On9YIFPRleVp/5G7z9g=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.4.0.tgz",
+      "integrity": "sha512-JGIpigWM3EBWvnS3rtBuefkiToIILSK1HYMXy4BCsUpO+O4UeeV+/U1AdAXgCB6qJrnPNb7yLgBsVCQUNMteig=="
+    },
+    "xterm-addon-attach": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.4.0.tgz",
+      "integrity": "sha512-va1dagNs9ao1aj06cRCbyTXe4POBhOa0y7Qc6q9Z2Z9bgHt9zCANeP5tKM8d0SMKSPmRnxfQ2F4P11iwB/Tzsw=="
+    },
+    "xterm-addon-fit": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.3.0.tgz",
+      "integrity": "sha512-kvkiqHVrnMXgyCH9Xn0BOBJ7XaWC/4BgpSWQy3SueqximgW630t/QOankgqkvk11iTOCwWdAY9DTyQBXUMN3lw=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "ngx-markdown": "^8.2.1",
     "rxjs": "^6.5.4",
     "tslib": "^1.10.0",
-    "xterm": "^3.14.5",
+    "xterm": "^4.3.0",
+    "xterm-addon-attach": "^0.4.0",
+    "xterm-addon-fit": "^0.3.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {

--- a/src/app/scenario/ctr.component.scss
+++ b/src/app/scenario/ctr.component.scss
@@ -1,0 +1,12 @@
+pre {
+  margin-bottom: 0;
+  padding: 5px 10px;
+  word-wrap: break;
+  white-space: break-spaces;
+  background: #292b2e;
+  color: #c5c8c6;
+}
+
+i {
+  font-size: 0.7em;
+}

--- a/src/app/scenario/ctr.component.ts
+++ b/src/app/scenario/ctr.component.ts
@@ -8,11 +8,7 @@ import { OnMount } from '../dynamic-html';
         <pre (click)="ctr()">{{code}}</pre>
         <i><clr-icon shape="angle"></clr-icon> Click to run on {{target}}</i>
     `,
-    styles: [
-        'pre { margin-bottom: 0; }',
-        'pre { padding-left: 5px; }',
-        'i { font-size: 0.7em; }'
-    ]
+    styleUrls: ['ctr.component.scss']
 })
 export class CtrComponent implements OnMount {
     public id: string = "";

--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -1,70 +1,61 @@
-<div class="clr-row">
-    <div class="clr-col">
-        <button class="btn" [class.btn-success-outline]="(this.scenario.stepcount-1) != this.stepnumber"
-            [class.btn-success]="(this.scenario.stepcount-1) == this.stepnumber" (click)="goFinish()">Finish <clr-icon
-                shape="check"></clr-icon></button>
-        <ng-container *ngIf="scenario.pauseable">
-            <button class="btn" (click)="pause()">
-                <clr-icon shape="pause" class="is-solid"></clr-icon> Pause Scenario
+<div class="clr-row clr-no-gutters">
+    <div class="clr-col-md-12 clr-col-lg-4 clr-col-xl-3 card" id="sidebar">
+        <div class="card-header">
+            <h3 id="scenario-name">{{ scenario.name | atob }}</h3>
+
+            <button class="btn btn-next"
+                [class.btn-success-outline]="(this.scenario.stepcount-1) != this.stepnumber"
+                [class.btn-success]="(this.scenario.stepcount-1) == this.stepnumber" (click)="goFinish()">
+                <clr-icon shape="check"></clr-icon>
+                Finish
             </button>
-            <clr-signpost>
-                <clr-signpost-content *clrIfOpen>
-                    <p>
-                        Pausing your scenario prevents removal of your VMs in case of network disconnection, timeout,
-                        etc.
-                    </p>
-                </clr-signpost-content>
-            </clr-signpost>
-        </ng-container>
-    </div>
-</div>
-<div class="clr-row">
-    <div class="clr-col-12">
-        <h4>{{ scenario.name | atob }}</h4>
-    </div>
-    <div class="clr-col-12">
-        <div class="progress labeled success">
-            <progress max="100" [value]="getProgress() || 0" data-displayval="0%"></progress>
-            <span>{{getProgress()}}%</span>
+            <ng-container *ngIf="scenario.pauseable">
+                <button class="btn" (click)="pause()">
+                    <clr-icon shape="pause" class="is-solid"></clr-icon> Pause
+                </button>
+                <clr-signpost style="z-index: 100000;">
+                    <clr-signpost-content [clrPosition]="'bottom-right'" *clrIfOpen>
+                        Pausing your scenario prevents removal of your VMs in case of network disconnection, timeout, etc.
+                    </clr-signpost-content>
+                </clr-signpost>
+            </ng-container>
         </div>
-    </div>
-</div>
-<div class="clr-row">
-    <div class="clr-col-4">
-        <div class="card">
-            <div class="card-block">
-                <h4 class="card-title">{{ step.title | atob }}</h4>
-                <div class="card-text">
-                    <dynamic-html [content]="stepcontent | markdown"></dynamic-html>
-                </div>
+
+        <div class="card-block" #contentdiv>
+            <h4 class="card-title">{{ step.title | atob }}</h4>
+            <div class="card-text">
+                <dynamic-html [content]="stepcontent | markdown"></dynamic-html>
             </div>
-            <div class="card-footer">
+        </div>
+
+        <div class="card-footer">
+            <div class="progress">
+                <!-- <div class="progress-meter" data-value="getProgress()"></div> -->
+                <progress [value]="getProgress() || 0" max="100"></progress>
+            </div>
+            <div id="step-navigator">
                 <button class="btn btn-outline btn-previous" (click)="goPrevious()" [disabled]="this.stepnumber < 1">
-                    <clr-icon shape="arrow" dir="left"></clr-icon> Previous
+                    <clr-icon shape="arrow" dir="left"></clr-icon> Prev
                 </button>
-                <button class="btn btn-next" *ngIf="(this.scenario.stepcount-1) > this.stepnumber"
-                    (click)="goNext()">Next <clr-icon shape="arrow" dir="right"></clr-icon></button>
-                <button class="btn btn-success btn-next" (click)="goFinish()"
-                    *ngIf="(this.scenario.stepcount-1) == this.stepnumber">Finish <clr-icon shape="check">
-                    </clr-icon></button>
+                <span id="step-counter">
+                    {{ this.stepnumber }}/{{( this.scenario.stepcount - 1) }}
+                </span>
+                <button class="btn btn-next" *ngIf="(this.scenario.stepcount-1) > this.stepnumber" (click)="goNext()">
+                    Next <clr-icon shape="arrow" dir="right"></clr-icon>
+                </button>
+                <button class="btn btn-success btn-next" (click)="goFinish()" *ngIf="(this.scenario.stepcount-1) == this.stepnumber">
+                    Finish <clr-icon shape="check"></clr-icon>
+                </button>
             </div>
         </div>
     </div>
-    <div class="clr-col-8 sticky-terminal">
-        <clr-tabs class="terminals">
-            <clr-tab>
-                <button clrTabLink>
-                    <clr-icon size="24" shape="unknown-status"></clr-icon> Info
-                </button>
-                <clr-tab-content>
-                    Use the tabs to navigate between shell sessions on your provisioned VMs.
-                </clr-tab-content>
-            </clr-tab>
-            <clr-tab *ngFor="let v of vmclaimvms | keyvalue" #tab>
+    <div class="clr-col-md-12 clr-col-lg-8 clr-col-xl-9" id="terminal-column">
+        <clr-tabs>
+            <clr-tab *ngFor="let v of vmclaimvms | keyvalue; let first = first;" #tab>
                 <button clrTabLink [id]="v.key">
                     <clr-icon size="24" shape="host"></clr-icon> {{ v.key }}
                 </button>
-                <clr-tab-content #tabcontent>
+                <clr-tab-content *clrIfActive="first" #tabcontent>
                     <table class="table compact">
                         <tr>
                             <td><b>Public IP:</b> {{ getVm(v.value.vm_id)?.public_ip }}</td>
@@ -86,9 +77,13 @@
         Are you sure you want to finish?
     </h3>
     <div class="modal-body">
-        <p>
-            Finishing a scenario will immediately de-provision your resources. Any VMs that you are using will be wiped.
-        </p>
+      <p *ngIf="session.course; else no_course">
+        Your VMs will be kept until they expire or the course is marked as "complete".
+      </p>
+      <ng-template #no_course>
+        Finishing a scenario will immediately de-provision your resources. Any VMs that you are using will be wiped.
+      </ng-template>
+
     </div>
     <div class="modal-footer">
         <button class="btn btn-outline" (click)="finishOpen = false">Cancel</button>

--- a/src/app/scenario/step.component.scss
+++ b/src/app/scenario/step.component.scss
@@ -1,20 +1,19 @@
-code {
-    background-color: rgba(0,0,0,0.1);
-    padding: 3px;
-    border-radius: 3px;
+.clr-no-gutters {
+  // undo the padding added by .content-area
+  margin: -1rem;
 }
 
 .btn-next {
     float: right;
 }
 
-.sticky-terminal {
+#terminal-column {
     position: fixed;
-    right: 0.25em;
-}
-
-.terminals {
-    padding: 3px;
+    right: 0;
+    padding: 0;
+    bottom: 0;
+    height: calc(100% - 60px);
+    width: 100%;
 }
 
 span.shell-status {
@@ -23,7 +22,67 @@ span.shell-status {
     background-color: white;
 }
 
+// clr-col-md
+@media all and (max-width: 992px) {
+  #terminal-column {
+    height: calc(50% - 60px);
+  }
+  #sidebar {
+    height: calc(50%) !important;
+  }
+
+}
+
+#step-navigator {
+  display: flex;
+  align-items: center;
+  button {
+    margin: 0;
+  }
+}
+#step-counter {
+  flex-grow: 2;
+  text-align: center;
+}
+
+
 table {
     margin-top: 0;
 }
 
+.progress span {
+  margin-top: -0.5em;
+}
+.progress {
+  margin-bottom: 1rem;
+}
+
+#sidebar {
+  position: fixed;
+  margin: 0;
+  height: calc(100% - 60px);
+  display: flex;
+  flex-flow: column;
+}
+#sidebar .card-header {
+  padding-top: 0;
+  flex: 0 1 auto;
+}
+#sidebar .card-block {
+  display: flex;
+  flex-flow: column;
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+#sidebar .card-footer {
+  flex: 0 1 40px;
+}
+
+
+#scenario-name {
+  text-align: center;
+  padding-bottom: 1rem;
+}
+.card-text {
+  padding-bottom: 2rem;
+}

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -24,6 +24,7 @@ import { VMService } from '../services/vm.service';
 import { VMInfoConfig } from '../VMInfoConfig';
 import { environment } from 'src/environments/environment';
 import { ShellService } from '../services/shell.service';
+import { escape } from 'lodash';
 
 
 @Component({
@@ -43,6 +44,8 @@ export class StepComponent implements OnInit, DoCheck {
     public stepcontent: string = "";
     public shellStatus: Map<string, string> = new Map();
 
+    public terminalActive: boolean = true;
+    public first: boolean = false;
     public finishOpen: boolean = false;
 
 
@@ -91,6 +94,7 @@ export class StepComponent implements OnInit, DoCheck {
     @ViewChildren('tab') tabs: QueryList<ClrTab> = new QueryList();
     @ViewChild('markdown', { static: false }) markdownTemplate;
     @ViewChild('pausemodal', { static: true }) pauseModal: ClrModal;
+    @ViewChild('contentdiv', { static: false }) contentDiv: ElementRef;
 
     constructor(
         public route: ActivatedRoute,
@@ -313,6 +317,7 @@ export class StepComponent implements OnInit, DoCheck {
         this.stepnumber += 1;
         this.router.navigateByUrl("/app/session/" + this.session.id + "/steps/" + (this.stepnumber));
         this._loadStep();
+        this.contentDiv.nativeElement.scrollTop = 0;
     }
 
     private _loadStep() {
@@ -335,19 +340,24 @@ export class StepComponent implements OnInit, DoCheck {
         this.stepnumber -= 1;
         this.router.navigateByUrl("/app/session/" + this.session.id + "/steps/" + (this.stepnumber));
         this._loadStep();
+        this.contentDiv.nativeElement.scrollTop = 0;
     }
 
-    goFinish() {
+    public goFinish() {
         this.finishOpen = true;
     }
 
     actuallyFinish() {
+      if (this.session.course) {
+        this.router.navigateByUrl("/app/home");
+      } else {
         this.http.put(environment.server + "/session/" + this.route.snapshot.paramMap.get("session") + "/finished", {})
             .subscribe(
                 (s: ServerResponse) => {
                     this.router.navigateByUrl("/app/home");
                 }
             )
+      }
 
     }
 

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -109,11 +109,10 @@ export class StepComponent implements OnInit, DoCheck {
         public shellService: ShellService
     ) {
         this.markdownService.renderer.code = (code: string, language: string, isEscaped: boolean) => {
-            // non-special code
-            if (language.length < 1) {
-                return "<pre>" + code + "</pre>";
+            // block text
+            if (language.length == 0) {
+                return "<pre  style='padding: 5px 10px;'>" + escape(code) + "</pre>";
             }
-
             // determine what kind of special injection we need to do
             if (language.split(":")[0] == 'ctr') {
                 // generate a new ID
@@ -134,6 +133,13 @@ export class StepComponent implements OnInit, DoCheck {
                 this.vmInfoService.setConfig(config);
 
                 return `<vminfo id="${config.id}"></vminfo>`;
+            } else {
+                // highlighted code
+                return "<pre style='padding: 5px 10px;' class='language-"+language+"'>" +
+                         "<code class='language-"+ language +"'>" +
+                           escape(code) +
+                         "</code>" +
+                       "</pre>";
             }
         }
     }

--- a/src/app/scenario/terminal.component.html
+++ b/src/app/scenario/terminal.component.html
@@ -1,1 +1,1 @@
-<div #terminal class="terminal"></div>
+<div class="terminal-div" (window:resize)="onResize()" #terminal></div>

--- a/src/app/scenario/terminal.component.scss
+++ b/src/app/scenario/terminal.component.scss
@@ -1,0 +1,11 @@
+.terminal-div {
+  height: calc(100% - 60px);
+  width: 100%;
+}
+
+.xterm {
+  padding-bottom: 30px;
+}
+.xterm-viewport {
+  overflow: hidden !important;
+}

--- a/src/app/scenario/terminal.component.ts
+++ b/src/app/scenario/terminal.component.ts
@@ -1,7 +1,7 @@
-import { Component, ViewChild, ElementRef, OnInit, Input, OnChanges } from '@angular/core';
+import { Component, ViewChild, ElementRef, OnInit, Input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { Terminal } from 'xterm';
-import * as attach from 'xterm/lib/addons/attach/attach';
-import * as fit from 'xterm/lib/addons/fit/fit';
+import { AttachAddon } from 'xterm-addon-attach';
+import { FitAddon } from 'xterm-addon-fit';
 import { JwtHelperService } from '@auth0/angular-jwt';
 import { CtrService } from './ctr.service';
 import { CodeExec } from './CodeExec';
@@ -13,8 +13,9 @@ import { HostListener } from '@angular/core';
     selector: 'terminal',
     templateUrl: './terminal.component.html',
     styleUrls: [
-        'terminal.component.css'
-    ]
+        'terminal.component.scss'
+    ],
+    encapsulation: ViewEncapsulation.None,
 })
 export class TerminalComponent implements OnChanges {
     @Input()
@@ -26,61 +27,29 @@ export class TerminalComponent implements OnChanges {
     @Input()
     endpoint: string;
 
-    terminalWidth: number = 80;
-
-    public screenHeight: number;
-    public screenWidth: number;
-
     public term: any;
+    public fitAddon: FitAddon;
+    public attachAddon: AttachAddon;
     public socket: WebSocket;
     constructor(
         public jwtHelper: JwtHelperService,
         public ctrService: CtrService,
         public shellService: ShellService
     ) {
-        this.screenHeight = window.innerHeight;
-        this.screenWidth = window.innerWidth;
-    }
 
-    @HostListener('window:resize', ['$event'])
-    onResize(event?) {
-        this.screenHeight = window.innerHeight;
-        this.screenWidth = window.innerWidth;
-        this.term.resize(this.terminalWidth, Math.floor(this.screenHeight * this.scalingFactor));
     }
 
     public paste(code: string) {
         this.term.write(code);
     }
 
-    public get scalingFactor() {
-        // determine scaling factor. 
-        if (this.screenHeight >= 1200) {
-            return 0.04;
-        } else if (this.screenHeight >= 992) {
-            return 0.03;
-        } else if (this.screenHeight >= 768) {
-            return 0.03;
-        } else if (this.screenHeight >= 576) {
-            return 0.03;
-        } else if (this.screenHeight < 576) {
-            return 0.025;
-        } else {
-            return 0.04;
-        }
-    }
-
     @ViewChild("terminal", { static: true }) terminalDiv: ElementRef;
 
     public resize() {
-        setTimeout(() => this.term.resize(this.terminalWidth, Math.floor(this.screenHeight * this.scalingFactor)), 150);
+        this.fitAddon.fit();
     }
 
     buildSocket() {
-        Terminal.applyAddon(attach);
-        Terminal.applyAddon(fit);
-        this.term = new Terminal();
-
         if (!this.endpoint.startsWith("wss://") && !this.endpoint.startsWith("ws://")) {
             if (environment.server.startsWith("https")) {
               this.endpoint = "wss://" + this.endpoint
@@ -89,6 +58,20 @@ export class TerminalComponent implements OnChanges {
             }
         }
         this.socket = new WebSocket(this.endpoint + "/shell/" + this.vmid + "/connect?auth=" + this.jwtHelper.tokenGetter());
+
+        this.term = new Terminal({
+          theme: {
+            background: '#292b2e'
+          },
+          fontFamily: "monospace",
+          fontSize: 16,
+          letterSpacing: 1.1
+        });
+        this.attachAddon = new AttachAddon(this.socket);
+        this.fitAddon = new FitAddon();
+        this.term.loadAddon(this.fitAddon)
+        this.term.open(this.terminalDiv.nativeElement);
+        this.fitAddon.fit();
 
         this.socket.onclose = (e) => {
             this.term.dispose(); // destroy the terminal on the page to avoid bad display
@@ -103,8 +86,8 @@ export class TerminalComponent implements OnChanges {
 
         this.socket.onopen = (e) => {
             this.shellService.setStatus(this.vmname, "Connected");
-            this.term.attach(this.socket, true, true);
-            this.term.open(this.terminalDiv.nativeElement);
+            this.term.loadAddon(this.attachAddon)
+            this.term.focus();
 
             this.ctrService.getCodeStream()
                 .subscribe(
@@ -137,5 +120,9 @@ export class TerminalComponent implements OnChanges {
         if (this.vmid != null && this.endpoint != null) {
             this.buildSocket();
         }
+    }
+
+    onResize() {
+      this.fitAddon.fit()
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,8 @@
 @import "./theme.scss";
 @import "../node_modules/@clr/ui/src/main.scss";
 
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: #f8f8f8 !important;
+}
+


### PR DESCRIPTION
These changes attempt to use the screen real estate for the terminal and sidebar a little better.

The terminal should now be fullscreen, however the pty hasn't been modified to accommodate a variable width so there are some issues with text being prematurely wrapped. The sidebar has also been rearranged a bit. Syntax highlighting was enabled for a few common languages and the color schema of CTR blocks was inverted to help stand out.

It looks a bit like this:

![Screenshot from 2020-04-01 21-11-30](https://user-images.githubusercontent.com/32495955/78201034-1d093500-7480-11ea-8e74-96f9a9568108.png)