### PR TITLE
added scenario close button

### DIFF
--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -3,6 +3,8 @@
         <button class="btn" [class.btn-success-outline]="(this.scenario.stepcount-1) != this.stepnumber"
             [class.btn-success]="(this.scenario.stepcount-1) == this.stepnumber" (click)="goFinish()">Finish <clr-icon
                 shape="check"></clr-icon></button>
+        <button class="btn" [class.btn-outline]="(this.scenario.stepcount-1) != this.stepnumber" (click)="goClose()">Close Scenario <clr-icon
+                shape="window-close"></clr-icon></button>
         <ng-container *ngIf="scenario.pauseable">
             <button class="btn" (click)="pause()">
                 <clr-icon shape="pause" class="is-solid"></clr-icon> Pause Scenario
@@ -80,6 +82,21 @@
         </clr-tabs>
     </div>
 </div>
+
+<clr-modal [(clrModalOpen)]="closeOpen">
+    <h3 class="modal-title">
+        Are you sure you want to close this scenario?
+    </h3>
+    <div class="modal-body">
+        <p>
+            Closing a scenario will retain your existing VMs. You may choose another scenario or return to this one. 
+        </p>
+    </div>
+    <div class="modal-footer">
+        <button class="btn btn-outline" (click)="closeOpen = false">Cancel</button>
+        <button class="btn btn-success-outline" (click)="actuallyClose()">Close Scenario</button>
+    </div>
+</clr-modal>
 
 <clr-modal [(clrModalOpen)]="finishOpen">
     <h3 class="modal-title">

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -44,7 +44,7 @@ export class StepComponent implements OnInit, DoCheck {
     public shellStatus: Map<string, string> = new Map();
 
     public finishOpen: boolean = false;
-
+    public closeOpen: boolean = false;
 
     public params: ParamMap;
 
@@ -343,6 +343,14 @@ export class StepComponent implements OnInit, DoCheck {
                 }
             )
 
+    }
+
+    goClose() {
+        this.closeOpen = true;
+    }
+
+    actuallyClose() {
+        this.router.navigateByUrl("/app/home");
     }
 
     public pause() {


### PR DESCRIPTION
Useful so as to provide a mechanism by which scenarios can be closed instead of finished, thus preserving the session in the case of Courses, where the VMs should remain alive for the duration. 