### PR TITLE
removed extraneous _refresh() call

### DIFF
--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -57,7 +57,6 @@ export class HomeComponent implements OnInit {
     }
 
     ngOnInit() {
-        this._refresh();
         this.userService.getModifiedObservable()
         .subscribe(
             (_) => {


### PR DESCRIPTION
Extraneous call to _refresh() in the home page .ts was causing multiple queries for the list of courses and scenarios on the home page.