### PR TITLE
Expired session

### DIFF
--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -135,3 +135,17 @@
         </button>
     </div>
 </clr-modal>
+
+<clr-modal #sessionExpiredModal [(clrModalOpen)]="sessionExpired" [clrModalClosable]="false">
+    <h3 class="modal-title">
+        Your session has expired! 
+    </h3>
+    <div class="modal-body">
+        <p>
+            Please return back to the home page.
+        </p>
+    </div>
+    <div class="modal-footer">
+        <button class="btn btn-outline" (click)="actuallyClose()">Ok</button>
+    </div>
+</clr-modal>

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -76,12 +76,16 @@ export class StepComponent implements OnInit, DoCheck {
             remaining += this.pauseremaining["h"] + ":";
         }
 
-        if (this.pauseremaining["m"] != 0) {
+        if (this.pauseremaining["m"] >= 10) {
             remaining += this.pauseremaining["m"];
+        } else {
+            remaining += "0" + this.pauseremaining["m"];
         }
 
-        if (this.pauseremaining["."] != 0) {
+        if (this.pauseremaining["."] >= 10) {
             remaining += ":" + this.pauseremaining["."];
+        } else {
+            remaining += ":0" + this.pauseremaining["."];
         }
 
         return remaining;

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -50,6 +50,7 @@ export class StepComponent implements OnInit, DoCheck {
     public params: ParamMap;
 
     public session: Session = new Session();
+    public sessionExpired: boolean = false;
     public vmclaimvms: Map<string, VMClaimVM> = new Map();
     public vms: Map<string, VM> = new Map();
 
@@ -151,7 +152,7 @@ export class StepComponent implements OnInit, DoCheck {
         return this.vmclaimvms.get(key);
     }
 
-    getVm(key: string) : VM {
+    getVm(key: string): VM {
         return this.vms.get(key);
     }
 
@@ -252,7 +253,12 @@ export class StepComponent implements OnInit, DoCheck {
                 retryWhen(errors => errors.pipe(
                     concatMap((e: HttpErrorResponse, i) =>
                         iif(
-                            () => e.status > 0,
+                            () => {
+                                if (e.status == 404) {
+                                    this.sessionExpired = true;
+                                }
+                                return e.status > 0
+                            },
                             throwError(e),
                             of(e).pipe(delay(10000))
                         )
@@ -292,11 +298,11 @@ export class StepComponent implements OnInit, DoCheck {
         )
 
         this.shellService.watch()
-        .subscribe(
-            (ss: Map<string, string>) => {
-                this.shellStatus = ss;
-            }
-        )
+            .subscribe(
+                (ss: Map<string, string>) => {
+                    this.shellStatus = ss;
+                }
+            )
     }
 
     private _splitTime(t: string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a session is deleted or  expired we should inform the user. 
Working with https://github.com/hobbyfarm/gargantua/pull/80. 

Minor fix: Prefixing single digit minutes/seconds for paused sessions.

**Which issue(s) this PR fixes**:
UI implementation for hobbyfarm/hobbyfarm#75