### PR TITLE
Fix for #146 and #147

### DIFF
--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -65,11 +65,11 @@
         <as-split-area size="60" #area2="asSplitArea" class="split-area-2">
             <div id="terminal-column">
                 <clr-tabs>
-                    <clr-tab *ngFor="let v of vmclaimvms | keyvalue; let first = first;" #tab>
+                    <clr-tab *ngFor="let v of vmclaimvms | keyvalue" #tab>
                         <button clrTabLink [id]="v.key">
                             <clr-icon size="24" shape="host"></clr-icon> {{ v.key }}
                         </button>
-                        <clr-tab-content *clrIfActive="first" #tabcontent>
+                        <clr-tab-content #tabcontent>
                             <table class="table compact">
                                 <tr>
                                     <td><b>Public IP:</b> {{ getVm(v.value.vm_id)?.public_ip }}</td>

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChildren, QueryList, ViewChild, Renderer2, ElementRef, AfterViewInit } from "@angular/core";
+import { Component, OnInit, ViewChildren, QueryList, ViewChild, Renderer2, ElementRef, AfterViewInit, OnDestroy } from "@angular/core";
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { Step } from '../Step';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
@@ -37,7 +37,7 @@ import { SplitAreaDirective, SplitComponent } from "angular-split";
     ]
 })
 
-export class StepComponent implements OnInit, AfterViewInit {
+export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
     public scenario: Scenario = new Scenario();
     public step: Step = new Step();
     public steps: string[] = [];
@@ -334,33 +334,14 @@ export class StepComponent implements OnInit, AfterViewInit {
     }
 
     ngAfterViewInit() {
-        this.tabContents.changes.forEach((tabContents: QueryList<ClrTabContent>) => {
-            // For each tab...
-            tabContents.forEach((t: ClrTabContent, i: number) => {
-                // ... watch the change stream for the active tab in the set ...
-                t.ifActiveService.currentChange.subscribe(
-                    (activeTabId: number) => {
-                        // ... if the active tab is the same as itself ...
-                        if (activeTabId == t.id) {
-                            // ... resize the terminal that corresponds to the index of the active tab.
-                            // e.g. tab could have ID of 45, but would be index 2 in list of tabs, so reload terminal with index 2.
-                            this.terms.toArray().forEach((term: TerminalComponent, index: number) => {
-                                if (i == index) {
-                                    term.setIsActive(true);
-                                    setTimeout(() => {
-                                        term.resize();
-                                    }, 500)
-                                } else {
-                                    term.setIsActive(false);
-                                }
-                            })
-                        }
-                    }
-                )
-            });
-        });
         this.tabs.changes.pipe(first()).subscribe((tabs: QueryList<ClrTab>) => {
             tabs.first.tabLink.activate();
+        })
+    }
+
+    ngOnDestroy() {
+        this.terms.forEach(term => {
+            term.mutationObserver.disconnect();
         })
     }
 

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -351,7 +351,7 @@ export class StepComponent implements OnInit, AfterViewInit {
                                         term.resize();
                                     }, 500)
                                 } else {
-                                    this.terms.toArray()[index].setIsActive(false);
+                                    term.setIsActive(false);
                                 }
                             })
                         }

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChildren, QueryList, DoCheck, ViewChild, Renderer2, ElementRef } from "@angular/core";
+import { Component, OnInit, ViewChildren, QueryList, ViewChild, Renderer2, ElementRef, AfterViewInit } from "@angular/core";
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { Step } from '../Step';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
@@ -37,7 +37,7 @@ import { SplitAreaDirective, SplitComponent } from "angular-split";
     ]
 })
 
-export class StepComponent implements OnInit, DoCheck {
+export class StepComponent implements OnInit, AfterViewInit {
     public scenario: Scenario = new Scenario();
     public step: Step = new Step();
     public steps: string[] = [];
@@ -333,6 +333,37 @@ export class StepComponent implements OnInit, DoCheck {
             )
     }
 
+    ngAfterViewInit() {
+        this.tabContents.changes.forEach((tabContents: QueryList<ClrTabContent>) => {
+            // For each tab...
+            tabContents.forEach((t: ClrTabContent, i: number) => {
+                // ... watch the change stream for the active tab in the set ...
+                t.ifActiveService.currentChange.subscribe(
+                    (activeTabId: number) => {
+                        // ... if the active tab is the same as itself ...
+                        if (activeTabId == t.id) {
+                            // ... resize the terminal that corresponds to the index of the active tab.
+                            // e.g. tab could have ID of 45, but would be index 2 in list of tabs, so reload terminal with index 2.
+                            this.terms.toArray().forEach((term: TerminalComponent, index: number) => {
+                                if (i == index) {
+                                    term.setIsActive(true);
+                                    setTimeout(() => {
+                                        term.resize();
+                                    }, 500)
+                                } else {
+                                    this.terms.toArray()[index].setIsActive(false);
+                                }
+                            })
+                        }
+                    }
+                )
+            });
+        });
+        this.tabs.changes.pipe(first()).subscribe((tabs: QueryList<ClrTab>) => {
+            tabs.first.tabLink.activate();
+        })
+    }
+
     private _splitTime(t: string) {
         var times: string[] = [];
         var timesegments = Object.keys(this.pauseremaining);
@@ -456,38 +487,21 @@ export class StepComponent implements OnInit, DoCheck {
             )
     }
 
-    public dragEnd({ sizes }: {gutterNum: number, sizes: Array<number>}) {
+    public dragEnd({ sizes }: { gutterNum: number, sizes: Array<number> }) {
         this.sizes.percent.area1 = sizes[0];
         this.sizes.percent.area2 = sizes[1];
         // For each tab...
         this.tabContents.forEach((t: ClrTabContent, i: number) => {
-                    // ... if the active tab is the same as itself ...
-                    if (t.ifActiveService.current == t.id) {
-                        // ... resize the terminal that corresponds to the index of the active tab.
-                        // e.g. tab could have ID of 45, but would be index 2 in list of tabs, so reload terminal with index 2.
-                        this.terms.toArray()[i].resize();
-                    }
+            // ... if the active tab is the same as itself ...
+            if (t.ifActiveService.current == t.id) {
+                // ... resize the terminal that corresponds to the index of the active tab.
+                // e.g. tab could have ID of 45, but would be index 2 in list of tabs, so reload terminal with index 2.
+                this.terms.toArray()[i].resize();
+            }
         });
     }
 
     escapeRegExp(string) {
         return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-    }
-
-    ngDoCheck() {
-        // For each tab...
-        this.tabContents.forEach((t: ClrTabContent, i: number) => {
-            // ... watch the change stream for the active tab in the set ...
-            t.ifActiveService.currentChange.subscribe(
-                (activeTabId: number) => {
-                    // ... if the active tab is the same as itself ...
-                    if (activeTabId == t.id) {
-                        // ... resize the terminal that corresponds to the index of the active tab.
-                        // e.g. tab could have ID of 45, but would be index 2 in list of tabs, so reload terminal with index 2.
-                        this.terms.toArray()[i].resize();
-                    }
-                }
-            )
-        });
     }
 }

--- a/src/app/scenario/terminal.component.html
+++ b/src/app/scenario/terminal.component.html
@@ -1,1 +1,1 @@
-<div class="terminal-div" (window:resize)="onResize()" #terminal></div>
+<div class="terminal-div" #terminal></div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents terminal reconnect on node switch. 

Since calling xterm.fit() with a non-visable terminal results in a thrown error and WebSocket.send() might throw an error if the socket is not defined or in state connected, I implemented a 500ms timeout before calling the resize-function when switching tabs. There might be a more elegant solution for this.  

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/146
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/147