### PR TITLE
Add glossary markdown renderer

### DIFF
--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -161,7 +161,11 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
                     "<summary>" + language.split(":")[1] + "</summary>" +
                     this.markdownService.compile(code) +
                     "</details>";
-            } else {
+            } else if (language.split(":")[0] == 'glossary') {
+                return "<div class='glossary'>" + language.split(":")[1] +
+                    "<span class='glossary-content'>" + this.markdownService.compile(code) + 
+                    "</span></div>";
+            }else {
                 // highlighted code
                 return "<pre style='padding: 5px 10px;' class='language-" + language + "'>" +
                     "<code class='language-" + language + "'>" +

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -25,3 +25,37 @@ summary {
   display: list-item;
   cursor: pointer;
 }
+
+
+.glossary {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+  
+}
+
+
+.glossary .glossary-content {
+  visibility: hidden;
+  width: 200px;
+  background-color: black;
+  text-align: center;
+  padding: 10px;
+  border-radius: 6px;
+  width: 120px;
+  top: 100%;
+  left: 60px;
+  margin-left: -60px; /* Use half of the width (120/2 = 60), to center the tooltip */
+
+  position: absolute;
+  z-index: 1;
+
+  p {
+    color: #fff;
+    margin-top: 0;
+  }
+}
+
+.glossary:hover .glossary-content {
+  visibility: visible;
+}


### PR DESCRIPTION
This PR fixes https://github.com/hobbyfarm/hobbyfarm/issues/156

Markdown Syntax:
~~~
```glossary:Helm
Helm is a cool tool that provides many features
```
~~~


results in
![tooltip_text](https://user-images.githubusercontent.com/86782124/135599329-a5933060-66ad-4ef8-bd6a-6e80116fdb15.PNG)
![tooltip](https://user-images.githubusercontent.com/86782124/135599333-e2dda011-c157-4717-a146-2ae570014951.PNG)

