### PR TITLE
Limit the clicks for CTR Executions

### DIFF
--- a/src/app/scenario/ctr.component.scss
+++ b/src/app/scenario/ctr.component.scss
@@ -12,3 +12,7 @@ pre {
   i {
     font-size: 0.7em;
   }
+
+  b{
+    color: #282828;
+  }

--- a/src/app/scenario/ctr.component.ts
+++ b/src/app/scenario/ctr.component.ts
@@ -6,7 +6,7 @@ import { OnMount } from '../dynamic-html';
     selector: 'ctr',
     template:  `
         <pre (click)="ctr()">{{code}}</pre>
-        <i><clr-icon shape="angle"></clr-icon> Click to run on {{target}}</i>
+        <i><clr-icon shape="angle"></clr-icon> Click to run on <b>{{target}}</b><span> {{countContent}}</span></i>
     `,
     styleUrls: ['ctr.component.scss']
 })
@@ -15,6 +15,8 @@ export class CtrComponent implements OnMount {
 
     public code: string = "";
     public target: string = "";
+    public count: number = Number.POSITIVE_INFINITY;
+    public countContent: string = "";
 
     constructor(
         public ctrService: CtrService
@@ -25,9 +27,25 @@ export class CtrComponent implements OnMount {
         this.id = attrs.get("ctrid");
         this.code = this.ctrService.getCode(this.id);
         this.target = this.ctrService.getTarget(this.id);
+        this.count = this.ctrService.getCount(this.id);
+        if(this.count != Number.POSITIVE_INFINITY){
+            this.updateCount();
+        }
     }
 
     public ctr() {
-        this.ctrService.sendCode({target: this.target, code: this.code});
+        if(this.count > 0){
+            this.ctrService.sendCode({target: this.target, code: this.code});
+            if(this.count != Number.POSITIVE_INFINITY){
+                this.count -= 1;
+                this.updateCount()
+            }
+        }
+    }
+
+    private updateCount(){
+        let clicks = this.count == 1 ? "click" : "clicks";
+        let content = `(${this.count} ${clicks} left)`
+        this.countContent = content;
     }
 }

--- a/src/app/scenario/ctr.service.ts
+++ b/src/app/scenario/ctr.service.ts
@@ -8,6 +8,7 @@ import {CodeExec} from './CodeExec';
 export class CtrService {
     private targets: Map<string, string> = new Map();
     private code: Map<string, string> = new Map();
+    private maxCount: Map<string, number> = new Map();
 
     private ctrstream: BehaviorSubject<CodeExec> = new BehaviorSubject(null);
 
@@ -23,12 +24,20 @@ export class CtrService {
         this.code.set(id, code);
     }
 
+    public setCount(id: string, count: number) {
+        this.maxCount.set(id, count);
+    }
+
     public getTarget(id: string) {
         return this.targets.get(id);
     }
 
     public getCode(id: string) {
         return this.code.get(id);
+    }
+
+    public getCount(id: string) {
+        return this.maxCount.get(id);
     }
 
     public sendCode(ctr: CodeExec) {

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -140,9 +140,16 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
             if (language.split(":")[0] == 'ctr') {
                 // generate a new ID
                 var id = ctr.generateId();
+                let maxCount = Number.POSITIVE_INFINITY;
                 ctr.setCode(id, code);
                 // split the language (ctr:target)
                 ctr.setTarget(id, language.split(":")[1]);
+
+                if(language.split(":").length > 2 && !isNaN(Number(language.split(":")[2]))){
+                    maxCount = Number(language.split(":")[2]);
+                }
+
+                ctr.setCount(id, maxCount)
 
                 return '<ctr ctrid="' + id + '"></ctr>'
             } else if (language.split(":")[0] == 'vminfo') {


### PR DESCRIPTION
This PR adds the ability to limit the ctr executions.

Markdown to limit the number of executions
~~~
```ctr:node01:2
echo Limits to 2 clicks
```
~~~

Markdown for unlimited executions.
~~~
```ctr:node01
echo No Limit
```
~~~

Results in 
![ctr_limit](https://user-images.githubusercontent.com/86782124/136353511-fb78ad67-2eaf-468a-b094-82f275e26778.PNG)

This PR fixes https://github.com/hobbyfarm/hobbyfarm/issues/102