### PR TITLE
Improve loading scenarios after changing access codes

### DIFF
--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -9,8 +9,11 @@
   <div class="clr-row">
 
     <div class="clr-col-12">
-      <div *ngIf="!courses && !scenarios">
+      <div *ngIf="!courses && !scenarios && loadedScenarios && loadedCourses">
         No scenarios or courses found.
+      </div>
+      <div *ngIf="!loadedScenarios && !loadedCourses">
+        Loading scenarios...
       </div>
     </div>
 

--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -18,6 +18,8 @@ import { ScenarioService } from './services/scenario.service';
 export class HomeComponent implements OnInit {
     public courses: Course[] = [];
     public scenarios: Scenario[] = [];
+    public loadedScenarios = false;
+    public loadedCourses = false;
     public showScenarioModal: boolean = false;
     public scenarioid: string;
     public courseid: string;
@@ -47,11 +49,19 @@ export class HomeComponent implements OnInit {
         this.courseService.list().subscribe(
             (c: Course[]) => {
                 this.courses = c;
+                this.loadedCourses = true;
+            },
+            (error: any)=>{
+                this.loadedCourses = false;
             }
         )
         this.scenarioService.list().subscribe(
             (s: Scenario[]) => {
                 this.scenarios = s;
+                this.loadedScenarios = true;
+            },
+            (error: any)=>{
+                this.loadedScenarios = false;
             }
         )
     }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpErrorResponse } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
-import { switchMap, catchError } from 'rxjs/operators';
+import { switchMap, catchError, tap } from 'rxjs/operators';
 import { ServerResponse } from '../ServerResponse';
 import { from, of, throwError, BehaviorSubject } from 'rxjs';
 import { atou } from '../unicode';
@@ -48,22 +48,22 @@ export class UserService {
   public addAccessCode(a: string) {
     var params = new HttpParams()
     .set("access_code", a);
-    this._acModified.next(true);
     return this.http.post<ServerResponse>(environment.server + "/auth/accesscode", params)
     .pipe(
       catchError((e: HttpErrorResponse) => {
         return throwError(e.error);
-      })
+      }),
+      tap(()=>this._acModified.next(true))
     )
   }
 
   public deleteAccessCode(a: string) {
-    this._acModified.next(true);
     return this.http.delete<ServerResponse>(environment.server + "/auth/accesscode/" + a)
     .pipe(
       catchError((e: HttpErrorResponse) => {
         return throwError(e.error);
-      })
+      }),
+      tap(()=>this._acModified.next(true))
     )
   }
 


### PR DESCRIPTION
This PR fixes https://github.com/hobbyfarm/hobbyfarm/issues/14

When the scenarios are being loaded we now display "Loading scenarios" instead of "no Scenarios found".

Also adding and removing access codes now results in the scenarios being loaded without the need to reload the page.
This was a bug where the observers were notified before sending a request to gargantua. Now the subscribers are notified after the request is done.