### PR TITLE
Fix pipeline using node:lts-alpine3.10

### DIFF
--- a/cicd/docker/Dockerfile
+++ b/cicd/docker/Dockerfile
@@ -1,5 +1,5 @@
 ##### sdk image #####
-FROM node:lts-alpine AS sdk
+FROM node:lts-alpine3.10 AS sdk
 
 RUN apk add python make g++
 


### PR DESCRIPTION
This commit fixes the broken pipeline. Using node with tag lts-alpine3.10 will let the pipeline run