### PR TITLE
Remove course ID from course header

### DIFF
--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -27,7 +27,7 @@
   <div class="clr-row">
     <div class="clr-col-12">
       <ng-container *ngFor="let c of courses">
-        <h2 class="course-header">{{ c.id }} - {{ c.name | atob }}</h2>
+        <h2 class="course-header">{{ c.name | atob }}</h2>
         <span *ngIf="c.inProgress">
           <button class="btn btn-info-outline">Complete</button>
         </span>


### PR DESCRIPTION
Removes the course ID from the course header on the course selection page.

Before: c-iur5emp4m3 - Coursename
After: Coursename

Fixes svalabs/ui#18