### PR TITLE
Fix error related to input name mismatch

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -146,7 +146,7 @@
               <clr-tab-content *clrIfActive="true">
                   <div *ngFor="let theme of availableThemes" class="radio-box-container clr-col-6">
                     <label class="theme-preview-radio-box clr-col-md-12">
-                      <input class="theme-preview-radio-button" type="radio" [value]="theme" name="terminal-theme" formControlName="selected_theme"/>
+                      <input class="theme-preview-radio-button" type="radio" [value]="theme" name="selected_theme" formControlName="selected_theme"/>
                       <div class="theme-preview-container">
                         <div class="theme-preview-terminal" [ngStyle]="{'background-color': theme.styles.background}">
                           <div class="theme-preview-terminal-text">


### PR DESCRIPTION
Fixes the following error that occurs in the browser console:

    If you define both a name and a formControlName attribute on your radio button, their values must match.
    Ex: <input type="radio" formControlName="food" name="food">

The old `name` attribute is not referenced anywhere in this repository, so this should be safe.

The bug was probably introduced in #90