### PR TITLE
Remove undeclared dependency on lodash

### DIFF
--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -25,8 +25,10 @@ import { VMInfoConfig } from '../VMInfoConfig';
 import { environment } from 'src/environments/environment';
 import { ShellService } from '../services/shell.service';
 import { atou } from '../unicode';
-import { escape } from 'lodash';
 import { ProgressService } from "../services/progress.service";
+
+// Replacement for lodash's escape
+const escape = (s: string) => s.replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`);
 
 @Component({
     templateUrl: 'step.component.html',


### PR DESCRIPTION
This replaces usage of `_.escape` with our own implementation.

This has the following advantages:

- no (undeclared) dependency on `lodash`
- 500kB smaller vendor bundle (in dev build)
- no warnings about optimization bailout during builds or in browser console