### PR TITLE
Simpler Markdown rendering

### DIFF
--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -36,6 +36,7 @@
                         <dynamic-html
                             id="step-content"
                             [content]="stepcontent | markdown"
+                            (click)="handleStepContentClick($event)"
                         ></dynamic-html>
                     </div>
                 </div>

--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -33,7 +33,10 @@
                 <div class="card-block" #contentdiv>
                     <h4 class="card-title">{{this.stepnumber + 1}}. {{ step.title | atob }}</h4>
                     <div class="card-text">
-                        <dynamic-html [content]="stepcontent | markdown"></dynamic-html>
+                        <dynamic-html
+                            id="step-content"
+                            [content]="stepcontent | markdown"
+                        ></dynamic-html>
                     </div>
                 </div>
 

--- a/src/app/scenario/step.component.scss
+++ b/src/app/scenario/step.component.scss
@@ -103,3 +103,33 @@ table {
     overflow-y: hidden !important;
     padding-left: 0.6rem;
   }
+
+// Styles for the rendered markdown
+#step-content ::ng-deep {
+  p {
+    margin: 0;
+
+    code {
+      display: inline-block;
+      padding: 1px 10px 2px 10px;
+      font-weight: bold;
+      color: #039BE5;
+      background-color: #ddd;
+      border-radius: 10px;
+    }
+  }
+
+  pre {
+    padding: 5px 10px;
+    overflow-x: auto;
+  }
+
+  details {
+    margin: 10px 0;
+  }
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+}

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -218,18 +218,13 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
                     "</pre>";
             }
         }
+    }
 
-        // Overriding the default link renderer to provide >> target="_blank" <<
-        this.markdownService.renderer.link = (href: string, title: string, text: string) => {
-            if (href === null) {
-                return text;
-            }
-            let out = '<a href="' + escape(href) + '" target="_blank"';
-            if (title) {
-                out += ' title="' + title + '"';
-            }
-            out += '>' + text + '</a>';
-            return out;
+    handleStepContentClick(e: MouseEvent) {
+        // Open all links in a new window
+        if (e.target instanceof HTMLAnchorElement && e.target.href) {
+            e.preventDefault();
+            window.open(e.target.href, '_blank');
         }
     }
 

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -158,17 +158,17 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
                             content += "~~~~~~";
                         }
                     })
-                    return "<pre style='padding: 5px 10px;overflow-x: auto;'>" + content + "</pre>";
+                    return "<pre>" + content + "</pre>";
                 } else {
                     // code block is empty or only contains white spaces
                     if(!code.trim()) {
-                        return "<pre style='padding: 5px 10px;overflow-x: auto;'></pre>";
+                        return "<pre></pre>";
                     }
                     // Prevent leading blank lines from being removed on non-empty code blocks 
                     else if (/^\n/.test(code)) {
-                        return "<pre style='padding: 5px 10px;overflow-x: auto;'>" + "\n" + escape(code) + "</pre>";
+                        return "<pre>" + "\n" + escape(code) + "</pre>";
                     } else {
-                        return "<pre style='padding: 5px 10px;overflow-x: auto;'>" + escape(code) + "</pre>";
+                        return "<pre>" + escape(code) + "</pre>";
                     }
                 }
             }
@@ -201,7 +201,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
 
                 return `<vminfo id="${config.id}"></vminfo>`;
             } else if (language.split(":")[0] == 'hidden') {
-                return "<details style='margin: 10px 0px;'>" +
+                return "<details>" +
                     "<summary>" + language.split(":")[1] + "</summary>" +
                     this.markdownService.compile(code) +
                     "</details>";
@@ -211,7 +211,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
                     "</span></div>";
             }else {
                 // highlighted code
-                return "<pre style='padding: 5px 10px;' class='language-" + language + "'>" +
+                return "<pre class='language-" + language + "'>" +
                     "<code class='language-" + language + "'>" +
                     escape(code) +
                     "</code>" +
@@ -230,28 +230,6 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
             }
             out += '>' + text + '</a>';
             return out;
-        }
-
-        this.markdownService.renderer.codespan = (code: string) => {
-            const style: string = 'style="color:#039BE5;font-weight:bold;background-color:#ddd;padding:1px 10px 2px 10px;border-radius:10px;display:inline-block;"';
-            return '<code ' + style + '>' + code + '</code>';
-        }
-
-        this.markdownService.renderer.image = (href: string, title: string, text: string) => {
-            if (href === null) {
-                return text;
-            }
-
-            const style = 'width: 100%;height: auto;';
-            let out = '<img src="' + href + '" alt="' + text + '" style="' + style + '"';
-            if (title) {
-                out += ' title="' + title + '"';
-            }
-            return out;
-        }
-
-        this.markdownService.renderer.paragraph = (text: string) => {
-            return "<p style='margin-top: 0;'>" + text + "</p>\n";
         }
     }
 


### PR DESCRIPTION
In the existing code, the implementation of the Markown renderer had been extended for simple things like styling generated DOM Elements or adding a `target="_blank"` to links, so they open in new windows/tabs.

This PR moves element styles to a SCSS file and implements the "open all links in new tab" feature by leveraging event bubbling. This way, error prone and repetitive string manipulation can be avoided.