### PR TITLE
Simplify "Use DOM renderer for Firefox. (#89)"

### DIFF
--- a/src/app/scenario/terminal.component.ts
+++ b/src/app/scenario/terminal.component.ts
@@ -78,7 +78,7 @@ export class TerminalComponent implements OnChanges, AfterViewInit, OnDestroy {
 
         // Check if current browser is firefox by useragent and use "duck-typing" as a fallback.
         const regExp: RegExp = /firefox|fxios/i;
-        const isFirefox: boolean = regExp.test(navigator.userAgent.toLowerCase()) || typeof InstallTrigger !== 'undefined';
+        const isFirefox: boolean = regExp.test(navigator.userAgent.toLowerCase()) || 'InstallTrigger' in window;
         this.term = new Terminal({
             theme: this.getTerminalTheme(this.terminal_theme),
             fontFamily: "monospace",

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -6,8 +6,7 @@
   },
   "files": [
     "main.ts",
-    "polyfills.ts",
-    "types.d.ts"
+    "polyfills.ts"
   ],
   "include": [
     "src/**/*.d.ts"

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -9,8 +9,7 @@
   },
   "files": [
     "test.ts",
-    "polyfills.ts",
-    "types.d.ts"
+    "polyfills.ts"
   ],
   "include": [
     "**/*.spec.ts",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,1 +1,0 @@
-declare const InstallTrigger: any;


### PR DESCRIPTION
This rephrases the TS from commit ccc22cd37d79 so that we do not need to define any custom types.

CC @PhilipAB 