### PR TITLE
fix(Course): align scenarios type w/ reality

### DIFF
--- a/src/app/course/course.ts
+++ b/src/app/course/course.ts
@@ -1,9 +1,8 @@
-import { Scenario } from '../scenario/Scenario';
-
 export class Course {
     id: string;
     name: string;
     description: string;
     scenarioCount: number;
-    scenarios: Scenario[];
+    // These are Scenario IDs
+    scenarios: string[];
 }

--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -36,8 +36,8 @@
 
         <div class="clr-row">
           <ng-container *ngIf="c.scenarios?.length > 0; else no_scenarios">
-            <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3" *ngFor="let s of c?.scenarios">
-              <scenario-card [scenarioid]="s" [(courseid)]="c.id" (scenarioModal)="toggleScenarioModal($event)">
+            <div class="clr-col-12 clr-col-sm-6 clr-col-md-4 clr-col-lg-3" *ngFor="let sId of c?.scenarios">
+              <scenario-card [scenarioid]="sId" [(courseid)]="c.id" (scenarioModal)="toggleScenarioModal($event)">
               </scenario-card>
             </div>
           </ng-container>


### PR DESCRIPTION
The type of the `scenarios` field in the `Course` type did not match what we get from the server.

This PR fixes the type and uses a more obvious variable name in a template.