### PR TITLE
refactor: cleanup settings code

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -144,9 +144,9 @@
             <clr-tab>
               <button clrTabLink>Terminal Theme</button>
               <clr-tab-content *clrIfActive="true">
-                  <div *ngFor="let theme of availableThemes" class="radio-box-container clr-col-6">
+                  <div *ngFor="let theme of themes" class="radio-box-container clr-col-6">
                     <label class="theme-preview-radio-box clr-col-md-12">
-                      <input class="theme-preview-radio-button" type="radio" [value]="theme" name="selected_theme" formControlName="selected_theme"/>
+                      <input class="theme-preview-radio-button" type="radio" [value]="theme.id" name="terminal_theme" formControlName="terminal_theme" />
                       <div class="theme-preview-container">
                         <div class="theme-preview-terminal" [ngStyle]="{'background-color': theme.styles.background}">
                           <div class="theme-preview-terminal-text">

--- a/src/app/scenario/terminal-themes/themes.ts
+++ b/src/app/scenario/terminal-themes/themes.ts
@@ -5,15 +5,12 @@ import Solarized_Dark_Higher_Contrast from './Solarized_Dark_Higher_Contrast';
 import GitHub from './GitHub';
 import Dichromatic from './Dichromatic';
 
-//Themes taken from https://github.com/ysk2014/xterm-theme
-const availableThemes = [
-    {'theme': 'default', 'name': 'Default Hobbyfarm Terminal', 'styles': Hobbyfarm_Default},
-    {'theme': 'Solarized_Light', 'name': 'Solarized Light', 'styles': Solarized_Light},
-    {'theme': 'Solarized_Dark', 'name': 'Solarized Dark', 'styles': Solarized_Dark},
-    {'theme': 'Solarized_Dark_Higher_Contrast', 'name': 'Solarized Dark Higher Contrast', 'styles': Solarized_Dark_Higher_Contrast },
-    {'theme': 'GitHub', 'name': 'GitHub', 'styles': GitHub },
-    {'theme': 'Dichromatic', 'name': 'Dichromatic', 'styles': Dichromatic }
-];
-
-export {availableThemes};
-export default {availableThemes};
+// Themes taken from https://github.com/ysk2014/xterm-theme
+export const themes = [
+    {id: 'default', name: 'Default Hobbyfarm Terminal', styles: Hobbyfarm_Default},
+    {id: 'Solarized_Light', name: 'Solarized Light', styles: Solarized_Light},
+    {id: 'Solarized_Dark', name: 'Solarized Dark', styles: Solarized_Dark},
+    {id: 'Solarized_Dark_Higher_Contrast', name: 'Solarized Dark Higher Contrast', styles: Solarized_Dark_Higher_Contrast },
+    {id: 'GitHub', name: 'GitHub', styles: GitHub },
+    {id: 'Dichromatic', name: 'Dichromatic', styles: Dichromatic }
+] as const;

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -33,21 +33,6 @@ export class UserService {
     )
   }
 
-  public updateSettings(newSettings: Map<string,string>) {
-    //Add all settings that need to be updated
-    var params = new HttpParams()
-    for (let [key, value] of newSettings.entries()) {
-      params = params.set(key, value);
-  }
-
-    return this.http.post<ServerResponse>(environment.server + "/auth/settings", params)
-    .pipe(
-      catchError((e: HttpErrorResponse) => {
-        return throwError(e.error);
-      })
-    )
-  }
-
   public getAccessCodes() {
     return this.http.get(environment.server + "/auth/accesscode")
     .pipe(


### PR DESCRIPTION
Code cleanup regarding all things related to user settings. Also sets the stage for another PR that I am preparing.

- refactor: simpler theme settings logic
- refactor: make terminal themes readonly
- refactor: use BehaviorSubject as cache
- refactor: move updateSettings
- refactor: settings service methods
- refactor: use typed settings
- refactor: allow updating settings w/ a partial
- feat: use cached settings once loaded