### PR TITLE
Fix progress color when step is over total steps

### DIFF
--- a/src/app/scenario/scenariocard.component.ts
+++ b/src/app/scenario/scenariocard.component.ts
@@ -112,7 +112,7 @@ export class ScenarioCard implements OnInit, OnChanges {
             return "status-finished"
         }
 
-        if(this.progress.max_step == this.progress.total_step){
+        if(this.progress.max_step >= this.progress.total_step){
             return "status-success";
         }
         return "status-running";


### PR DESCRIPTION
When the max_step is greater than the total_step the wrong color is displayed. 