### PR TITLE
fix: handle "no scenarios" case

### DIFF
--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -25,7 +25,14 @@
 
   <div class="clr-row">
     <div class="clr-col-12">
-      <div *ngIf="!courses && !scenarios && loadedScenarios && loadedCourses">
+      <div
+        *ngIf="
+          !courses.length &&
+          !scenarios.length &&
+          loadedScenarios &&
+          loadedCourses
+        "
+      >
         No scenarios or courses found.
       </div>
       <div *ngIf="!loadedScenarios && !loadedCourses">Loading scenarios...</div>

--- a/src/app/services/gargantua.service.ts
+++ b/src/app/services/gargantua.service.ts
@@ -63,6 +63,10 @@ export class ListableResourceClient<
         if (!arr) return;
         this.cache = new Map(arr.map((it) => [it.id, it]));
       }),
+
+      // Ensure we are always returning an array
+      // Gargantua responds with null in certain cases
+      map((arr) => arr || []),
     );
   }
 }


### PR DESCRIPTION
This fixes a bug that was introduced in #125 and that causes a broken UI when there are no scenarios available to the logged-in user.

CC @jggoebel 