### PR TITLE
About config

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -10,10 +10,10 @@ export interface Config {
   };
   logo: string;
   about: {
-    title: string,
-    body: string,
-    buttons: {title: string, url: string}[]
-  }
+    title: string;
+    body: string;
+    buttons: { title: string; url: string }[];
+  };
 }
 
 @Injectable()

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -12,7 +12,7 @@ export interface Config {
   about: {
     title: string,
     body: string,
-    buttons: [{title: string, url: string}]
+    buttons: {title: string, url: string}[]
   }
 }
 

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -9,6 +9,11 @@ export interface Config {
     background: string;
   };
   logo: string;
+  about: {
+    title: string,
+    body: string,
+    buttons: [{title: string, url: string}]
+  }
 }
 
 @Injectable()

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -100,3 +100,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.about-body {
+  margin-bottom: 1em;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -63,10 +63,10 @@
   </clr-modal>
 
   <clr-modal #aboutmodal [(clrModalOpen)]="aboutModalOpened">
-    <h3 class="modal-title">About HobbyFarm</h3>
+    <h3 class="modal-title">{{ aboutTitle }}</h3>
     <div class="modal-body">
       <p>
-        HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs
+        {{ aboutBody }}
       </p>
       <p>
         <i>UI Version: {{ version }}</i>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -65,7 +65,7 @@
   <clr-modal #aboutmodal [(clrModalOpen)]="aboutModalOpened">
     <h3 class="modal-title">{{ aboutTitle }}</h3>
     <div class="modal-body">
-      <p>
+      <p class="about-body">
         {{ aboutBody }}
       </p>
       <ng-container *ngFor="let button of buttons">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,6 +71,14 @@
       <p>
         <i>UI Version: {{ version }}</i>
       </p>
+      <ng-container *ngFor="let button of buttons">
+        <a href="{{ button.url }}" target="_blank">
+          <button class="btn btn-sm btn-link">
+            {{ button.title }}
+            <clr-icon shape="pop-out"></clr-icon>
+          </button>
+        </a>
+      </ng-container>
     </div>
   </clr-modal>
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -68,9 +68,6 @@
       <p>
         {{ aboutBody }}
       </p>
-      <p>
-        <i>UI Version: {{ version }}</i>
-      </p>
       <ng-container *ngFor="let button of buttons">
         <a href="{{ button.url }}" target="_blank">
           <button class="btn btn-sm btn-link">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -52,7 +52,12 @@ export class AppComponent implements OnInit {
   public aboutBody =
     this.Config.about?.body ||
     'HobbyFarm is lovingly crafted by the HobbyFarm team';
-  public buttons = this.Config.about?.buttons || [];
+  public buttons = this.Config.about?.buttons || [
+    {
+      title: 'Hobbyfarm Project',
+      url: 'https://github.com/hobbyfarm/hobbyfarm',
+    },
+  ];
 
   public themes = themes;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,7 +53,7 @@ export class AppComponent implements OnInit {
   public aboutTitle = this.Config.about?.title || 'About HobbyFarm';
   public aboutBody =
     this.Config.about?.body ||
-    'HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs';
+    'HobbyFarm is lovingly crafted by the HobbyFarm team';
   public buttons = this.Config.about?.buttons || [];
 
   public themes = themes;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -52,6 +52,7 @@ export class AppComponent implements OnInit {
   private logo = this.Config.logo || '/assets/default/logo.svg';
   public aboutTitle = this.Config.about?.title || "About HobbyFarm";
   public aboutBody = this.Config.about?.body || "HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs";
+  public buttons = this.Config.about?.buttons || [];
 
   public themes = themes;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,8 +50,10 @@ export class AppComponent implements OnInit {
   private Config = this.config.getConfig();
   public title = this.Config.title || "Rancher's Hobby Farm";
   private logo = this.Config.logo || '/assets/default/logo.svg';
-  public aboutTitle = this.Config.about?.title || "About HobbyFarm";
-  public aboutBody = this.Config.about?.body || "HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs";
+  public aboutTitle = this.Config.about?.title || 'About HobbyFarm';
+  public aboutBody =
+    this.Config.about?.body ||
+    'HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs';
   public buttons = this.Config.about?.buttons || [];
 
   public themes = themes;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,6 +50,8 @@ export class AppComponent implements OnInit {
   private Config = this.config.getConfig();
   public title = this.Config.title || "Rancher's Hobby Farm";
   private logo = this.Config.logo || '/assets/default/logo.svg';
+  public aboutTitle = this.Config.about?.title || "About HobbyFarm";
+  public aboutBody = this.Config.about?.body || "HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs";
 
   public themes = themes;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,6 @@ import { ClarityIcons } from '@clr/icons';
 import { JwtHelperService } from '@auth0/angular-jwt';
 import { ClrModal } from '@clr/angular';
 import { Router } from '@angular/router';
-import { version } from 'src/environments/version';
 import { UserService } from './services/user.service';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ServerResponse } from './ServerResponse';
@@ -21,7 +20,6 @@ export class AppComponent implements OnInit {
   public logoutModalOpened = false;
   public aboutModalOpened = false;
   public changePasswordModalOpened = false;
-  public version: string;
 
   public changePwDangerClosed = true;
   public changePwSuccessClosed = true;
@@ -74,12 +72,6 @@ export class AppComponent implements OnInit {
     if (this.Config.favicon) {
       const fi = <HTMLLinkElement>document.querySelector('#favicon');
       fi.href = this.Config.favicon;
-    }
-
-    if (version.tag) {
-      this.version = version.tag;
-    } else {
-      this.version = version.revision;
     }
   }
 

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,6 @@
   "logo": "/assets/default/logo.svg",
   "about": {
     "title": "About HobbyFarm",
-    "body": "HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs"
+    "body": "HobbyFarm is lovingly crafted by the HobbyFarm team"
   }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,12 @@
   "logo": "/assets/default/logo.svg",
   "about": {
     "title": "About HobbyFarm",
-    "body": "HobbyFarm is lovingly crafted by the HobbyFarm team"
+    "body": "HobbyFarm is lovingly crafted by the HobbyFarm team",
+    "buttons": [
+      {
+        "title": "Hobbyfarm Project",
+        "url": "https://github.com/hobbyfarm/hobbyfarm"
+      }
+    ]
   }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -5,5 +5,9 @@
     "logo": "/assets/default/rancher-labs-stacked-color.svg",
     "background": "/assets/default/login_container_farm.svg"
   },
-  "logo": "/assets/default/logo.svg"
+  "logo": "/assets/default/logo.svg",
+  "about": {
+    "title": "About HobbyFarm",
+    "body": "HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs"
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- UI implementation to make the about section customizable
- Changed default values

The current default modal now looks like this:
![image](https://user-images.githubusercontent.com/38468835/162029286-92ff8240-8afe-45b7-a695-ec3cb6ae8c30.png)

Changing the about title or body text removes the default button automatically, e.g.:
![image](https://user-images.githubusercontent.com/38468835/162029513-dedcab21-d8d5-48c7-9e29-ae3f4f8b6e1c.png)
