### PR TITLE
Fix unset protocol bug

### DIFF
--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -292,7 +292,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   isGuacamoleTerminal(protocol: string): boolean {
-    return protocol !== 'ssh';
+    return !!protocol && protocol !== 'ssh';
   }
 
   public pause() {


### PR DESCRIPTION
This bug leads to the wrgon terminal being loaded when no protocol is ste in the vm templates.
Now the terminal defaults to SSH