### PR TITLE
Add style for inline codeblocks, ability to print session id in md

### DIFF
--- a/src/app/hf-markdown/hf-markdown.component.scss
+++ b/src/app/hf-markdown/hf-markdown.component.scss
@@ -4,7 +4,7 @@
     margin: 0;
 
     code {
-      font-family: Consolas,Monaco,Andale Mono,Ubuntu Mono,monospace;
+      font-family: Consolas, Monaco, Andale Mono, Ubuntu Mono, monospace;
       padding: 1px 10px 2px 10px;
       font-weight: bold;
       color: #000;
@@ -16,6 +16,7 @@
   pre {
     padding: 5px 10px;
     overflow-x: auto;
+    background-color: #f8f8f8;
   }
 
   details {

--- a/src/app/hf-markdown/hf-markdown.component.scss
+++ b/src/app/hf-markdown/hf-markdown.component.scss
@@ -4,12 +4,12 @@
     margin: 0;
 
     code {
-      display: inline-block;
+      font-family: Consolas,Monaco,Andale Mono,Ubuntu Mono,monospace;
       padding: 1px 10px 2px 10px;
       font-weight: bold;
-      color: #039be5;
-      background-color: #ddd;
-      border-radius: 10px;
+      color: #000;
+      background-color: #f4f4f4;
+      border-radius: 5px;
     }
   }
 

--- a/src/app/hf-markdown/hf-markdown.component.ts
+++ b/src/app/hf-markdown/hf-markdown.component.ts
@@ -133,6 +133,7 @@ export class HfMarkdownComponent implements OnChanges {
   }
 
   private replaceVmInfoTokens(content: string) {
+    console.log(this.context.vmInfo);
     return content.replace(
       /\$\{vminfo:([^:]*):([^}]*)\}/g,
       (match, vmName, propName) => {

--- a/src/app/hf-markdown/hf-markdown.component.ts
+++ b/src/app/hf-markdown/hf-markdown.component.ts
@@ -8,6 +8,7 @@ const escape = (s: string) =>
 
 export interface HfMarkdownRenderContext {
   vmInfo: { [vmName: string]: VM };
+  session: string;
 }
 
 @Component({
@@ -23,7 +24,7 @@ export interface HfMarkdownRenderContext {
 })
 export class HfMarkdownComponent implements OnChanges {
   @Input() content: string;
-  @Input() context: HfMarkdownRenderContext = { vmInfo: {} };
+  @Input() context: HfMarkdownRenderContext = { vmInfo: {}, session: '' };
 
   processedContent: string;
 
@@ -126,7 +127,9 @@ export class HfMarkdownComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    this.processedContent = this.replaceVmInfoTokens(this.content);
+    this.processedContent = this.replaceSessionToken(
+      this.replaceVmInfoTokens(this.content),
+    );
   }
 
   private replaceVmInfoTokens(content: string) {
@@ -137,5 +140,9 @@ export class HfMarkdownComponent implements OnChanges {
         return String(vm?.[propName as keyof VM] ?? match);
       },
     );
+  }
+
+  private replaceSessionToken(content: string) {
+    return content.replace(/\$\{session\}/g, this.context.session);
   }
 }

--- a/src/app/scenario/ctr.component.scss
+++ b/src/app/scenario/ctr.component.scss
@@ -4,7 +4,7 @@ pre {
   padding: 5px 10px;
   word-wrap: break;
   white-space: break-spaces;
-  background: #292b2e;
+  background: #292b2e !important;
   color: #c5c8c6;
   cursor: pointer;
   overflow-x: auto;

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -41,7 +41,7 @@ import { VMService } from '../services/vm.service';
 import { ShellService } from '../services/shell.service';
 import { atou } from '../unicode';
 import { ProgressService } from '../services/progress.service';
-import { HfMarkdownRenderContext } from '../hf-markdown/hf-markdown.component';
+import { HfMarkdownComponent, HfMarkdownRenderContext } from '../hf-markdown/hf-markdown.component';
 import { GuacTerminalComponent } from './guacTerminal.component';
 
 @Component({
@@ -63,7 +63,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   public sessionExpired = false;
   public vms: Map<string, VM> = new Map();
 
-  mdContext: HfMarkdownRenderContext = { vmInfo: {} };
+  mdContext: HfMarkdownRenderContext = { vmInfo: {}, session: "" };
 
   public pauseOpen = false;
 
@@ -153,7 +153,8 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
         for (const [k, v] of this.vms) {
           vmInfo[k.toLowerCase()] = v;
         }
-        this.mdContext = { vmInfo };
+        this.mdContext.vmInfo = vmInfo;
+        this.mdContext.session = this.session.id;
       });
 
     // setup keepalive

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -41,7 +41,10 @@ import { VMService } from '../services/vm.service';
 import { ShellService } from '../services/shell.service';
 import { atou } from '../unicode';
 import { ProgressService } from '../services/progress.service';
-import { HfMarkdownComponent, HfMarkdownRenderContext } from '../hf-markdown/hf-markdown.component';
+import {
+  HfMarkdownComponent,
+  HfMarkdownRenderContext,
+} from '../hf-markdown/hf-markdown.component';
 import { GuacTerminalComponent } from './guacTerminal.component';
 
 @Component({
@@ -63,7 +66,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   public sessionExpired = false;
   public vms: Map<string, VM> = new Map();
 
-  mdContext: HfMarkdownRenderContext = { vmInfo: {}, session: "" };
+  mdContext: HfMarkdownRenderContext = { vmInfo: {}, session: '' };
 
   public pauseOpen = false;
 
@@ -153,8 +156,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
         for (const [k, v] of this.vms) {
           vmInfo[k.toLowerCase()] = v;
         }
-        this.mdContext.vmInfo = vmInfo;
-        this.mdContext.session = this.session.id;
+        this.mdContext = { vmInfo: vmInfo, session: this.session.id };
       });
 
     // setup keepalive


### PR DESCRIPTION
In Step Content Markdown `${session}` will print the current Session ID.
Also edited the inline codeblocks to align with the style of other codeblocks

Before this change:
![before](https://user-images.githubusercontent.com/86782124/213447158-f50ff7b1-6eea-425e-902c-48bffcc53ee6.PNG)
![before_3](https://user-images.githubusercontent.com/86782124/213447184-aa9428e3-8bb0-40d6-ae1e-db4ad81bcf6e.PNG)

After this change:
![after](https://user-images.githubusercontent.com/86782124/213447209-52731544-c0a6-454d-87ea-7e747a14c401.PNG)
![before2](https://user-images.githubusercontent.com/86782124/213447228-43671b07-7699-46af-8afc-96ef22fadd10.PNG)
