### PR TITLE
[Markdown] Inline-code style for ul, ol

### DIFF
--- a/src/app/hf-markdown/hf-markdown.component.scss
+++ b/src/app/hf-markdown/hf-markdown.component.scss
@@ -2,7 +2,9 @@
 .hf-md-content ::ng-deep {
   p {
     margin: 0;
+  }
 
+  p, ol li, ul li{
     code {
       font-family: Consolas, Monaco, Andale Mono, Ubuntu Mono, monospace;
       padding: 1px 10px 2px 10px;

--- a/src/app/hf-markdown/hf-markdown.component.scss
+++ b/src/app/hf-markdown/hf-markdown.component.scss
@@ -4,7 +4,9 @@
     margin: 0;
   }
 
-  p, ol li, ul li{
+  p,
+  ol li,
+  ul li {
     code {
       font-family: Consolas, Monaco, Andale Mono, Ubuntu Mono, monospace;
       padding: 1px 10px 2px 10px;


### PR DESCRIPTION
Style for inline code blocks was not using the right css selector. 

With this PR we can use inline code inside ul and ol (numbered lists and lists)

![codeInUl](https://user-images.githubusercontent.com/86782124/215428906-fce2044e-a6ca-453c-ae5a-755777d53e03.PNG)

fixes https://github.com/hobbyfarm/hobbyfarm/issues/278