### PR TITLE
Improve service-tabs

### DIFF
--- a/src/app/hf-markdown/hf-markdown.component.ts
+++ b/src/app/hf-markdown/hf-markdown.component.ts
@@ -178,7 +178,6 @@ ${token}`;
   }
 
   private replaceVmInfoTokens(content: string) {
-    console.log(this.context.vmInfo);
     return content.replace(
       /\$\{vminfo:([^:]*):([^}]*)\}/g,
       (match, vmName, propName) => {

--- a/src/app/scenario/scenariocard.component.ts
+++ b/src/app/scenario/scenariocard.component.ts
@@ -4,6 +4,7 @@ import {
   Output,
   EventEmitter,
   OnChanges,
+  OnInit,
 } from '@angular/core';
 import { Scenario } from '../scenario/Scenario';
 import { ProgressService } from '../services/progress.service';
@@ -17,7 +18,7 @@ import { SessionService } from '../services/session.service';
   templateUrl: 'scenariocard.component.html',
   styleUrls: ['./scenariocard.component.scss'],
 })
-export class ScenarioCardComponent implements OnChanges {
+export class ScenarioCardComponent implements OnInit, OnChanges {
   @Input()
   public scenarioid = '';
   @Input()

--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -5,8 +5,12 @@
         <div class="card-header">
           <h3 id="scenario-name">{{ scenario.name | atob }}</h3>
 
-          <button class="btn btn-next" [class.btn-success-outline]="!isLastStepActive"
-            [class.btn-success]="isLastStepActive" (click)="goFinish()">
+          <button
+            class="btn btn-next"
+            [class.btn-success-outline]="!isLastStepActive"
+            [class.btn-success]="isLastStepActive"
+            (click)="goFinish()"
+          >
             <clr-icon shape="check"></clr-icon>
             Finish
           </button>
@@ -23,7 +27,11 @@
             </clr-signpost>
           </ng-container>
 
-          <button class="btn" [class.btn-outline]="!isLastStepActive" (click)="goClose()">
+          <button
+            class="btn"
+            [class.btn-outline]="!isLastStepActive"
+            (click)="goClose()"
+          >
             <clr-icon shape="window-close"></clr-icon>Close
           </button>
         </div>
@@ -33,8 +41,11 @@
             {{ this.stepnumber + 1 }}. {{ step.title | atob }}
           </h4>
           <div class="card-text">
-            <app-hf-markdown [content]="stepcontent" [context]="mdContext"
-              (click)="handleStepContentClick($event)"></app-hf-markdown>
+            <app-hf-markdown
+              [content]="stepcontent"
+              [context]="mdContext"
+              (click)="handleStepContentClick($event)"
+            ></app-hf-markdown>
           </div>
         </div>
 
@@ -44,16 +55,28 @@
             <progress [value]="getProgress() || 0" max="100"></progress>
           </div>
           <div id="step-navigator">
-            <button class="btn btn-outline btn-previous" (click)="goPrevious()" [disabled]="this.stepnumber < 1">
+            <button
+              class="btn btn-outline btn-previous"
+              (click)="goPrevious()"
+              [disabled]="this.stepnumber < 1"
+            >
               <clr-icon shape="arrow" dir="left"></clr-icon> Prev
             </button>
             <span id="step-counter">
               {{ this.stepnumber + 1 }}/{{ this.scenario.stepcount }}
             </span>
-            <button class="btn btn-next" *ngIf="!isLastStepActive" (click)="goNext()">
+            <button
+              class="btn btn-next"
+              *ngIf="!isLastStepActive"
+              (click)="goNext()"
+            >
               Next <clr-icon shape="arrow" dir="right"></clr-icon>
             </button>
-            <button class="btn btn-success btn-next" (click)="goFinish()" *ngIf="isLastStepActive">
+            <button
+              class="btn btn-success btn-next"
+              (click)="goFinish()"
+              *ngIf="isLastStepActive"
+            >
               <clr-icon shape="check"></clr-icon> Finish
             </button>
           </div>
@@ -66,7 +89,7 @@
           <clr-tab *ngFor="let v of vms | keyvalue" #tab>
             <button clrTabLink [id]="v.key">
               <clr-icon size="24" shape="host"></clr-icon> {{ v.key }}
-            </button>            
+            </button>
             <clr-tab-content #tabcontent>
               <table class="table compact">
                 <tr>
@@ -76,53 +99,101 @@
                   <td><b>Shell Status:</b> {{ getShellStatus(v.key) }}</td>
                 </tr>
               </table>
-              <app-terminal *ngIf="!isGuacamoleTerminal(v.value.protocol)" [vmname]="v.key" [vmid]="v.value.id"
-                [endpoint]="v.value.ws_endpoint" #term>
+              <app-terminal
+                *ngIf="!isGuacamoleTerminal(v.value.protocol)"
+                [vmname]="v.key"
+                [vmid]="v.value.id"
+                [endpoint]="v.value.ws_endpoint"
+                #term
+              >
               </app-terminal>
-              <app-guac-terminal *ngIf="isGuacamoleTerminal(v.value.protocol)" [vmname]="v.key" [vmid]="v.value.id"
-                [endpoint]="v.value.ws_endpoint" #guacterm>
+              <app-guac-terminal
+                *ngIf="isGuacamoleTerminal(v.value.protocol)"
+                [vmname]="v.key"
+                [vmid]="v.value.id"
+                [endpoint]="v.value.ws_endpoint"
+                #guacterm
+              >
               </app-guac-terminal>
             </clr-tab-content>
           </clr-tab>
           <ng-container *ngFor="let v of vms | keyvalue">
-            <ng-container *ngFor="let webinterface of v.value.webinterfaces, let i = index">
-              <clr-tab *ngIf="webinterface.hasOwnTab && i < maxInterfaceTabs || webinterface.active">
-                <button clrTabLink [clrTabLinkInOverflow]="false" (click)="setTabActive(webinterface)">
+            <ng-container
+              *ngFor="let webinterface of v.value.webinterfaces; let i = index"
+            >
+              <clr-tab
+                *ngIf="
+                  (webinterface.hasOwnTab && i < maxInterfaceTabs) ||
+                  webinterface.active
+                "
+              >
+                <button
+                  clrTabLink
+                  [clrTabLinkInOverflow]="false"
+                  (click)="setTabActive(webinterface)"
+                >
                   {{ v.key }} - {{ webinterface.name }}
                 </button>
                 <ng-template [(clrIfActive)]="webinterface.active">
-                <clr-tab-content>
-                  <table class="table compact">
-                    <tr>
-                      <td><b>Webinterface:</b> {{ webinterface.name }}</td>
-                      <td><b>Node:</b> {{ v.key }}</td>
-                      <td><b>Port:</b> {{ webinterface.port }}</td>
-                      <td><b>Path:</b> {{ webinterface.path }}</td>
-                      <td style="padding: 0">
-                        <button class="btn btn-icon btn-primary btn-sm" title="Reload Tab"
-                          (click)="reloadWebinterface(v.value.id, webinterface)">
-                          <clr-icon shape="refresh"></clr-icon>
-                        </button>
-                        <button class="btn btn-icon btn-primary btn-sm" title="Open in a new Tab" (click)="
-                          openWebinterfaceInNewTab(v.value, webinterface)
-                        ">
-                          <clr-icon shape="pop-out"></clr-icon>
-                        </button>
-                      </td>
-                    </tr>
-                  </table>
-                  <app-ide-window *ngIf="!isGuacamoleTerminal(v.value.protocol)" [vmid]="v.value.id"
-                    [endpoint]="v.value.ws_endpoint" [port]="webinterface.port" [path]="webinterface.path"
-                    [disallowIFrame]="webinterface.disallowIFrame" (openWebinterfaceFn)="
-                    openWebinterfaceInNewTab(v.value, webinterface)
-                  " [reloadEvent]="reloadTabObservable">
-                  </app-ide-window>
-                </clr-tab-content>
-              </ng-template>
+                  <clr-tab-content>
+                    <table class="table compact">
+                      <tr>
+                        <td><b>Webinterface:</b> {{ webinterface.name }}</td>
+                        <td><b>Node:</b> {{ v.key }}</td>
+                        <td><b>Port:</b> {{ webinterface.port }}</td>
+                        <td><b>Path:</b> {{ webinterface.path }}</td>
+                        <td style="padding: 0">
+                          <button
+                            class="btn btn-icon btn-primary btn-sm"
+                            title="Reload Tab"
+                            (click)="
+                              reloadWebinterface(v.value.id, webinterface)
+                            "
+                          >
+                            <clr-icon shape="refresh"></clr-icon>
+                          </button>
+                          <button
+                            class="btn btn-icon btn-primary btn-sm"
+                            title="Open in a new Tab"
+                            (click)="
+                              openWebinterfaceInNewTab(v.value, webinterface)
+                            "
+                          >
+                            <clr-icon shape="pop-out"></clr-icon>
+                          </button>
+                        </td>
+                      </tr>
+                    </table>
+                    <app-ide-window
+                      *ngIf="!isGuacamoleTerminal(v.value.protocol)"
+                      [vmid]="v.value.id"
+                      [endpoint]="v.value.ws_endpoint"
+                      [port]="webinterface.port"
+                      [path]="webinterface.path"
+                      [disallowIFrame]="webinterface.disallowIFrame"
+                      (openWebinterfaceFn)="
+                        openWebinterfaceInNewTab(v.value, webinterface)
+                      "
+                      [reloadEvent]="reloadTabObservable"
+                    >
+                    </app-ide-window>
+                  </clr-tab-content>
+                </ng-template>
               </clr-tab>
 
-              <clr-tab *ngIf="(!webinterface.hasOwnTab || ( webinterface.hasOwnTab && i >= maxInterfaceTabs)) && !webinterface.active" #tab>
-                <button clrTabLink [clrTabLinkInOverflow]="true" (click)="setTabActive(webinterface)">
+              <clr-tab
+                *ngIf="
+                  (!webinterface.hasOwnTab ||
+                    (webinterface.hasOwnTab && i >= maxInterfaceTabs)) &&
+                  !webinterface.active
+                "
+                #tab
+              >
+                <button
+                  clrTabLink
+                  [clrTabLinkInOverflow]="true"
+                  (click)="setTabActive(webinterface)"
+                >
                   {{ v.key }} - {{ webinterface.name }}
                 </button>
               </clr-tab>
@@ -187,7 +258,9 @@
       {{ pauseRemainingString }}
     </p>
     <p>
-      <span class="clr-subtext">Last updated at {{ pauseLastUpdated | date: 'medium' }}</span>
+      <span class="clr-subtext"
+        >Last updated at {{ pauseLastUpdated | date: 'medium' }}</span
+      >
     </p>
     <br />
   </div>
@@ -198,7 +271,11 @@
   </div>
 </clr-modal>
 
-<clr-modal #sessionExpiredModal [(clrModalOpen)]="sessionExpired" [clrModalClosable]="false">
+<clr-modal
+  #sessionExpiredModal
+  [(clrModalOpen)]="sessionExpired"
+  [clrModalClosable]="false"
+>
   <h3 class="modal-title">Your session has expired!</h3>
   <div class="modal-body">
     <p>Please return back to the home page.</p>

--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -5,12 +5,8 @@
         <div class="card-header">
           <h3 id="scenario-name">{{ scenario.name | atob }}</h3>
 
-          <button
-            class="btn btn-next"
-            [class.btn-success-outline]="!isLastStepActive"
-            [class.btn-success]="isLastStepActive"
-            (click)="goFinish()"
-          >
+          <button class="btn btn-next" [class.btn-success-outline]="!isLastStepActive"
+            [class.btn-success]="isLastStepActive" (click)="goFinish()">
             <clr-icon shape="check"></clr-icon>
             Finish
           </button>
@@ -27,11 +23,7 @@
             </clr-signpost>
           </ng-container>
 
-          <button
-            class="btn"
-            [class.btn-outline]="!isLastStepActive"
-            (click)="goClose()"
-          >
+          <button class="btn" [class.btn-outline]="!isLastStepActive" (click)="goClose()">
             <clr-icon shape="window-close"></clr-icon>Close
           </button>
         </div>
@@ -41,11 +33,8 @@
             {{ this.stepnumber + 1 }}. {{ step.title | atob }}
           </h4>
           <div class="card-text">
-            <app-hf-markdown
-              [content]="stepcontent"
-              [context]="mdContext"
-              (click)="handleStepContentClick($event)"
-            ></app-hf-markdown>
+            <app-hf-markdown [content]="stepcontent" [context]="mdContext"
+              (click)="handleStepContentClick($event)"></app-hf-markdown>
           </div>
         </div>
 
@@ -55,28 +44,16 @@
             <progress [value]="getProgress() || 0" max="100"></progress>
           </div>
           <div id="step-navigator">
-            <button
-              class="btn btn-outline btn-previous"
-              (click)="goPrevious()"
-              [disabled]="this.stepnumber < 1"
-            >
+            <button class="btn btn-outline btn-previous" (click)="goPrevious()" [disabled]="this.stepnumber < 1">
               <clr-icon shape="arrow" dir="left"></clr-icon> Prev
             </button>
             <span id="step-counter">
               {{ this.stepnumber + 1 }}/{{ this.scenario.stepcount }}
             </span>
-            <button
-              class="btn btn-next"
-              *ngIf="!isLastStepActive"
-              (click)="goNext()"
-            >
+            <button class="btn btn-next" *ngIf="!isLastStepActive" (click)="goNext()">
               Next <clr-icon shape="arrow" dir="right"></clr-icon>
             </button>
-            <button
-              class="btn btn-success btn-next"
-              (click)="goFinish()"
-              *ngIf="isLastStepActive"
-            >
+            <button class="btn btn-success btn-next" (click)="goFinish()" *ngIf="isLastStepActive">
               <clr-icon shape="check"></clr-icon> Finish
             </button>
           </div>
@@ -89,7 +66,7 @@
           <clr-tab *ngFor="let v of vms | keyvalue" #tab>
             <button clrTabLink [id]="v.key">
               <clr-icon size="24" shape="host"></clr-icon> {{ v.key }}
-            </button>
+            </button>            
             <clr-tab-content #tabcontent>
               <table class="table compact">
                 <tr>
@@ -99,74 +76,58 @@
                   <td><b>Shell Status:</b> {{ getShellStatus(v.key) }}</td>
                 </tr>
               </table>
-              <app-terminal
-                *ngIf="!isGuacamoleTerminal(v.value.protocol)"
-                [vmname]="v.key"
-                [vmid]="v.value.id"
-                [endpoint]="v.value.ws_endpoint"
-                #term
-              >
+              <app-terminal *ngIf="!isGuacamoleTerminal(v.value.protocol)" [vmname]="v.key" [vmid]="v.value.id"
+                [endpoint]="v.value.ws_endpoint" #term>
               </app-terminal>
-              <app-guac-terminal
-                *ngIf="isGuacamoleTerminal(v.value.protocol)"
-                [vmname]="v.key"
-                [vmid]="v.value.id"
-                [endpoint]="v.value.ws_endpoint"
-                #guacterm
-              >
+              <app-guac-terminal *ngIf="isGuacamoleTerminal(v.value.protocol)" [vmname]="v.key" [vmid]="v.value.id"
+                [endpoint]="v.value.ws_endpoint" #guacterm>
               </app-guac-terminal>
             </clr-tab-content>
           </clr-tab>
           <ng-container *ngFor="let v of vms | keyvalue">
-            <clr-tab *ngFor="let webinterface of v.value.webinterfaces" #tab>
-              <button
-                clrTabLink
-                [clrTabLinkInOverflow]="!webinterface.hasOwnTab"
-              >
-                {{ v.key }} - {{ webinterface.name }}
-              </button>
-              <clr-tab-content>
-                <table class="table compact">
-                  <tr>
-                    <td><b>Webinterface:</b> {{ webinterface.name }}</td>
-                    <td><b>Node:</b> {{ v.key }}</td>
-                    <td><b>Port:</b> {{ webinterface.port }}</td>
-                    <td><b>Path:</b> {{ webinterface.path }}</td>
-                    <td style="padding: 0">
-                      <button
-                        class="btn btn-icon btn-primary btn-sm"
-                        title="Reload Tab"
-                        (click)="reloadWebinterface(v.value.id, webinterface)"
-                      >
-                        <clr-icon shape="refresh"></clr-icon>
-                      </button>
-                      <button
-                        class="btn btn-icon btn-primary btn-sm"
-                        title="Open in a new Tab"
-                        (click)="
+            <ng-container *ngFor="let webinterface of v.value.webinterfaces, let i = index">
+
+              <clr-tab *ngIf="webinterface.hasOwnTab || webinterface.active" #tab>
+                <button clrTabLink [clrTabLinkInOverflow]="false" (click)="setTabActive(webinterface)">
+                  {{ v.key }} - {{ webinterface.name }}
+                </button>
+                <ng-template [(clrIfActive)]="webinterface.active">
+                <clr-tab-content #tabcontent>
+                  <table class="table compact">
+                    <tr>
+                      <td><b>Webinterface:</b> {{ webinterface.name }}</td>
+                      <td><b>Node:</b> {{ v.key }}</td>
+                      <td><b>Port:</b> {{ webinterface.port }}</td>
+                      <td><b>Path:</b> {{ webinterface.path }}</td>
+                      <td style="padding: 0">
+                        <button class="btn btn-icon btn-primary btn-sm" title="Reload Tab"
+                          (click)="reloadWebinterface(v.value.id, webinterface)">
+                          <clr-icon shape="refresh"></clr-icon>
+                        </button>
+                        <button class="btn btn-icon btn-primary btn-sm" title="Open in a new Tab" (click)="
                           openWebinterfaceInNewTab(v.value, webinterface)
-                        "
-                      >
-                        <clr-icon shape="pop-out"></clr-icon>
-                      </button>
-                    </td>
-                  </tr>
-                </table>
-                <app-ide-window
-                  *ngIf="!isGuacamoleTerminal(v.value.protocol)"
-                  [vmid]="v.value.id"
-                  [endpoint]="v.value.ws_endpoint"
-                  [port]="webinterface.port"
-                  [path]="webinterface.path"
-                  [disallowIFrame]="webinterface.disallowIFrame"
-                  (openWebinterfaceFn)="
+                        ">
+                          <clr-icon shape="pop-out"></clr-icon>
+                        </button>
+                      </td>
+                    </tr>
+                  </table>
+                  <app-ide-window *ngIf="!isGuacamoleTerminal(v.value.protocol)" [vmid]="v.value.id"
+                    [endpoint]="v.value.ws_endpoint" [port]="webinterface.port" [path]="webinterface.path"
+                    [disallowIFrame]="webinterface.disallowIFrame" (openWebinterfaceFn)="
                     openWebinterfaceInNewTab(v.value, webinterface)
-                  "
-                  [reloadEvent]="reloadTabObservable"
-                >
-                </app-ide-window>
-              </clr-tab-content>
-            </clr-tab>
+                  " [reloadEvent]="reloadTabObservable">
+                  </app-ide-window>
+                </clr-tab-content>
+              </ng-template>
+              </clr-tab>
+
+              <clr-tab *ngIf="!webinterface.hasOwnTab && !webinterface.active" #tab>
+                <button clrTabLink [clrTabLinkInOverflow]="true" (click)="setTabActive(webinterface)">
+                  {{ v.key }} - {{ webinterface.name }}
+                </button>
+              </clr-tab>
+            </ng-container>
           </ng-container>
         </clr-tabs>
       </div>
@@ -227,9 +188,7 @@
       {{ pauseRemainingString }}
     </p>
     <p>
-      <span class="clr-subtext"
-        >Last updated at {{ pauseLastUpdated | date: 'medium' }}</span
-      >
+      <span class="clr-subtext">Last updated at {{ pauseLastUpdated | date: 'medium' }}</span>
     </p>
     <br />
   </div>
@@ -240,11 +199,7 @@
   </div>
 </clr-modal>
 
-<clr-modal
-  #sessionExpiredModal
-  [(clrModalOpen)]="sessionExpired"
-  [clrModalClosable]="false"
->
+<clr-modal #sessionExpiredModal [(clrModalOpen)]="sessionExpired" [clrModalClosable]="false">
   <h3 class="modal-title">Your session has expired!</h3>
   <div class="modal-body">
     <p>Please return back to the home page.</p>

--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -62,7 +62,7 @@
     </as-split-area>
     <as-split-area [size]="60" class="split-area-2">
       <div id="terminal-column">
-        <clr-tabs>
+        <clr-tabs class="tab-container">
           <clr-tab *ngFor="let v of vms | keyvalue" #tab>
             <button clrTabLink [id]="v.key">
               <clr-icon size="24" shape="host"></clr-icon> {{ v.key }}
@@ -86,13 +86,12 @@
           </clr-tab>
           <ng-container *ngFor="let v of vms | keyvalue">
             <ng-container *ngFor="let webinterface of v.value.webinterfaces, let i = index">
-
-              <clr-tab *ngIf="webinterface.hasOwnTab || webinterface.active" #tab>
+              <clr-tab *ngIf="webinterface.hasOwnTab && i < maxInterfaceTabs || webinterface.active">
                 <button clrTabLink [clrTabLinkInOverflow]="false" (click)="setTabActive(webinterface)">
                   {{ v.key }} - {{ webinterface.name }}
                 </button>
                 <ng-template [(clrIfActive)]="webinterface.active">
-                <clr-tab-content #tabcontent>
+                <clr-tab-content>
                   <table class="table compact">
                     <tr>
                       <td><b>Webinterface:</b> {{ webinterface.name }}</td>
@@ -122,7 +121,7 @@
               </ng-template>
               </clr-tab>
 
-              <clr-tab *ngIf="!webinterface.hasOwnTab && !webinterface.active" #tab>
+              <clr-tab *ngIf="(!webinterface.hasOwnTab || ( webinterface.hasOwnTab && i >= maxInterfaceTabs)) && !webinterface.active" #tab>
                 <button clrTabLink [clrTabLinkInOverflow]="true" (click)="setTabActive(webinterface)">
                   {{ v.key }} - {{ webinterface.name }}
                 </button>

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -41,7 +41,7 @@ import { VMService } from '../services/vm.service';
 import { ShellService } from '../services/shell.service';
 import { atou } from '../unicode';
 import { ProgressService } from '../services/progress.service';
-import {
+import {  
   HfMarkdownComponent,
   HfMarkdownRenderContext,
 } from '../hf-markdown/hf-markdown.component';
@@ -55,6 +55,7 @@ type Service = {
   hasOwnTab: boolean;
   hasWebinterface: boolean;
   disallowIFrame: boolean;
+  active: boolean;
 };
 interface stepVM extends VM {
   webinterfaces?: Service[];
@@ -116,9 +117,20 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
     private vmClaimService: VMClaimService,
     private vmService: VMService,
     private shellService: ShellService,
-    private progressService: ProgressService,
+    private progressService: ProgressService,    
     private jwtHelper: JwtHelperService,
   ) {}
+
+  setTabActive(webinterface: Service) {
+    this.vms.forEach(vm=> {
+      vm.webinterfaces?.forEach(wi => {
+        wi.active = false
+        if (wi.name == webinterface.name) {
+          wi.active = true
+        }
+      })
+    })
+  }
 
   handleStepContentClick(e: MouseEvent) {
     // Open all links in a new window
@@ -182,7 +194,6 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
               const services = JSON.parse(JSON.parse(stringContent)); //TODO: See if we can skip one stringify somwhere, so we dont have to parse twice
               services.forEach((service: Service) => {
                 if (service.hasWebinterface) {
-                  console.log(service);
                   const webinterface = {
                     name: service.name ?? 'Service',
                     port: service.port ?? 80,
@@ -190,6 +201,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
                     hasOwnTab: !!service.hasOwnTab,
                     hasWebinterface: true,
                     disallowIFrame: !!service.disallowIFrame,
+                    active: false,
                   };
                   vm.webinterfaces
                     ? vm.webinterfaces.push(webinterface)

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -87,6 +87,8 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
 
   mdContext: HfMarkdownRenderContext = { vmInfo: {}, session: '' };
 
+  maxInterfaceTabs:number = 2;
+
   public pauseOpen = false;
 
   public pauseLastUpdated: Date = new Date();
@@ -279,6 +281,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
     this.tabs.changes.pipe(first()).subscribe((tabs: QueryList<ClrTab>) => {
       tabs.first.tabLink.activate();
     });
+    setTimeout(()=>this.calculateMaxInterfaceTabs(), 2000) 
   }
 
   ngOnDestroy() {
@@ -421,6 +424,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
         isActiveTab && this.terms.toArray()[i - numberOfGuacTabs].resize();
       }
     });
+    this.calculateMaxInterfaceTabs()
   }
 
   openWebinterfaceInNewTab(vm: stepVM, wi: Service) {
@@ -442,5 +446,30 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
       vmId: vmId,
       port: webinterface.port,
     } as webinterfaceTabIdentifier);
+  }
+
+  calculateMaxInterfaceTabs(reduce: boolean = false) {
+    let tabs = document.getElementsByTagName('li')
+    let tabsBarWidth: number | undefined = 0
+    let allTabsWidth: number = 0
+    const tabsArray = Array.from(tabs)
+    tabsArray.forEach((tab, i) => {
+      if (i == 0) {
+        tabsBarWidth = tab.parentElement?.offsetWidth        
+      }
+      allTabsWidth += tab.offsetWidth
+    })    
+    if (tabsBarWidth) {
+      let averageTabWidth = allTabsWidth/tabsArray.length
+      tabsBarWidth = (0.9 * tabsBarWidth - 1.5 * averageTabWidth)
+      if (allTabsWidth > tabsBarWidth) {
+        --this.maxInterfaceTabs
+        setTimeout(() => {this.calculateMaxInterfaceTabs(true)}, 10)
+      } else if (!reduce && (allTabsWidth + 1.5*(allTabsWidth/tabsArray.length) < tabsBarWidth)) {
+        ++this.maxInterfaceTabs
+        setTimeout(() => {this.calculateMaxInterfaceTabs()}, 10)
+      }
+    }
+    
   }
 }

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -449,9 +449,9 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   calculateMaxInterfaceTabs(reduce: boolean = false) {
-    let tabs = document.getElementsByTagName('li')
+    const tabs = document.getElementsByTagName('li')
     let tabsBarWidth: number | undefined = 0
-    let allTabsWidth: number = 0
+    let allTabsWidth = 0
     const tabsArray = Array.from(tabs)
     tabsArray.forEach((tab, i) => {
       if (i == 0) {
@@ -460,7 +460,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
       allTabsWidth += tab.offsetWidth
     })    
     if (tabsBarWidth) {
-      let averageTabWidth = allTabsWidth/tabsArray.length
+      const averageTabWidth = allTabsWidth/tabsArray.length
       tabsBarWidth = (0.9 * tabsBarWidth - 1.5 * averageTabWidth)
       if (allTabsWidth > tabsBarWidth) {
         --this.maxInterfaceTabs

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -87,7 +87,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
 
   mdContext: HfMarkdownRenderContext = { vmInfo: {}, session: '' };
 
-  maxInterfaceTabs:number = 2;
+  maxInterfaceTabs = 2;
 
   public pauseOpen = false;
 

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -119,19 +119,19 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
     private vmClaimService: VMClaimService,
     private vmService: VMService,
     private shellService: ShellService,
-    private progressService: ProgressService,    
+    private progressService: ProgressService,
     private jwtHelper: JwtHelperService,
   ) {}
 
   setTabActive(webinterface: Service) {
-    this.vms.forEach(vm=> {
-      vm.webinterfaces?.forEach(wi => {
-        wi.active = false
+    this.vms.forEach((vm) => {
+      vm.webinterfaces?.forEach((wi) => {
+        wi.active = false;
         if (wi.name == webinterface.name) {
-          wi.active = true
+          wi.active = true;
         }
-      })
-    })
+      });
+    });
   }
 
   handleStepContentClick(e: MouseEvent) {
@@ -285,7 +285,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
     this.tabs.changes.pipe(first()).subscribe((tabs: QueryList<ClrTab>) => {
       tabs.first.tabLink.activate();
     });
-    setTimeout(()=>this.calculateMaxInterfaceTabs(), 2000) 
+    setTimeout(() => this.calculateMaxInterfaceTabs(), 2000);
   }
 
   ngOnDestroy() {
@@ -428,7 +428,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
         isActiveTab && this.terms.toArray()[i - numberOfGuacTabs].resize();
       }
     });
-    this.calculateMaxInterfaceTabs()
+    this.calculateMaxInterfaceTabs();
   }
 
   openWebinterfaceInNewTab(vm: stepVM, wi: Service) {
@@ -453,27 +453,33 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   calculateMaxInterfaceTabs(reduce: boolean = false) {
-    const tabs = document.getElementsByTagName('li')
-    let tabsBarWidth: number | undefined = 0
-    let allTabsWidth = 0
-    const tabsArray = Array.from(tabs)
+    const tabs = document.getElementsByTagName('li');
+    let tabsBarWidth: number | undefined = 0;
+    let allTabsWidth = 0;
+    const tabsArray = Array.from(tabs);
     tabsArray.forEach((tab, i) => {
       if (i == 0) {
-        tabsBarWidth = tab.parentElement?.offsetWidth        
+        tabsBarWidth = tab.parentElement?.offsetWidth;
       }
-      allTabsWidth += tab.offsetWidth
-    })    
+      allTabsWidth += tab.offsetWidth;
+    });
     if (tabsBarWidth) {
-      const averageTabWidth = allTabsWidth/tabsArray.length
-      tabsBarWidth = (0.9 * tabsBarWidth - 1.5 * averageTabWidth)
+      const averageTabWidth = allTabsWidth / tabsArray.length;
+      tabsBarWidth = 0.9 * tabsBarWidth - 1.5 * averageTabWidth;
       if (allTabsWidth > tabsBarWidth) {
-        --this.maxInterfaceTabs
-        setTimeout(() => {this.calculateMaxInterfaceTabs(true)}, 10)
-      } else if (!reduce && (allTabsWidth + 1.5*(allTabsWidth/tabsArray.length) < tabsBarWidth)) {
-        ++this.maxInterfaceTabs
-        setTimeout(() => {this.calculateMaxInterfaceTabs()}, 10)
+        --this.maxInterfaceTabs;
+        setTimeout(() => {
+          this.calculateMaxInterfaceTabs(true);
+        }, 10);
+      } else if (
+        !reduce &&
+        allTabsWidth + 1.5 * (allTabsWidth / tabsArray.length) < tabsBarWidth
+      ) {
+        ++this.maxInterfaceTabs;
+        setTimeout(() => {
+          this.calculateMaxInterfaceTabs();
+        }, 10);
       }
     }
-    
   }
 }


### PR DESCRIPTION
Services that do not have a Tab in the UI get a Tab anyways as long as they are selected by the User.
Except from the currently selected Tab all Tabs can now be pushed to the Overflow-Dropdown, if there isn't enough space to show all of them.
Addresses https://github.com/hobbyfarm/hobbyfarm/issues/288 and https://github.com/hobbyfarm/hobbyfarm/issues/285