### PR TITLE
Save divider position to user settings

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -284,6 +284,26 @@
                     />
                   </clr-checkbox-wrapper>
                 </clr-checkbox-container>
+                <clr-input-container>
+                  <label class="clr-col-md-4">Divider Position</label>
+                  <input
+                    class="clr-col-md-8"
+                    clrInput
+                    type="number"
+                    required
+                    name="divider_position"
+                    formControlName="divider_position"
+                  />
+                  <clr-control-error *clrIfError="'required'"
+                    >Divider Position required.</clr-control-error
+                  >
+                  <clr-control-error *clrIfError="'min'"
+                    >Divider Position minimum is 0.</clr-control-error
+                  >
+                  <clr-control-error *clrIfError="'max'"
+                    >Divider Position maximum is 100.</clr-control-error
+                  >
+                </clr-input-container>
               </clr-tab-content>
             </clr-tab>
             <clr-tab>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -137,6 +137,11 @@ export class AppComponent implements OnInit {
       Validators.required,
     ]),
     ctr_enabled: new FormControl<boolean>(false),
+    divider_position: new FormControl<number | null>(null, [
+      Validators.required,
+      Validators.max(100),
+      Validators.min(0),
+    ]),
     theme: new FormControl<'light' | 'dark' | 'system' | null>(null, [
       Validators.required,
     ]),
@@ -273,12 +278,14 @@ export class AppComponent implements OnInit {
           terminal_fontSize = 16,
           ctr_enabled = true,
           theme = 'light',
+          divider_position = 40,
         }) => {
           this.settingsForm.setValue({
             terminal_theme,
             terminal_fontSize,
             ctr_enabled,
             theme,
+            divider_position,
           });
           this.fetchingSettings = false;
         },

--- a/src/app/scenario/step.component.html
+++ b/src/app/scenario/step.component.html
@@ -1,5 +1,10 @@
 <div class="split-container">
-  <as-split unit="percent" direction="horizontal" (dragEnd)="dragEnd()">
+  <as-split
+    unit="percent"
+    direction="horizontal"
+    (dragEnd)="dragEnd()"
+    #divider
+  >
     <as-split-area [size]="40" class="split-area-1">
       <div class="card" id="sidebar">
         <div class="card-header">

--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -512,12 +512,12 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   saveContentDivider() {
-    let dividerSize = this.divider.getVisibleAreaSizes()[0];
+    const dividerSize = this.divider.getVisibleAreaSizes()[0];
     let dividerSizeNumber = this.DEFAULT_DIVIDER_POSITION; // Default is 40% content, 60% terminal
     if (dividerSize != '*') {
       dividerSizeNumber = dividerSize;
     }
-    let dividerPosition = Math.round(dividerSizeNumber);
+    const dividerPosition = Math.round(dividerSizeNumber);
 
     this.settingsService
       .update({ divider_position: dividerPosition })
@@ -525,7 +525,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   setContentDividerPosition(percentage: number) {
-    let dividerPositions = [percentage, 100 - percentage];
+    const dividerPositions = [percentage, 100 - percentage];
     this.divider.setVisibleAreaSizes(dividerPositions);
     this.resizeTerminals();
   }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -21,6 +21,7 @@ export interface Settings {
   ctr_enabled: boolean;
   ctxAccessCode: string;
   theme: 'light' | 'dark' | 'system';
+  divider_position: number;
 }
 
 @Injectable()
@@ -43,6 +44,7 @@ export class SettingsService {
               ctr_enabled: true,
               ctxAccessCode: '',
               theme: 'light',
+              divider_position: 40,
             } as Settings),
       ),
       tap((s: Settings) => {


### PR DESCRIPTION
Saves the divider position (percentage of the content on the left side) to the user settings and restores it when reloading.
This way a user can set their preffered divider position.

The user can also set the value in the settings directly.

fixes https://github.com/hobbyfarm/hobbyfarm/issues/404