### PR TITLE
Implement automatic retry-mechanism for TunnelErrors

### DIFF
--- a/src/app/scenario/guacTerminal.component.ts
+++ b/src/app/scenario/guacTerminal.component.ts
@@ -53,6 +53,7 @@ export class GuacTerminalComponent implements OnChanges {
   public connectionState = states.IDLE;
   public errorMessage?: string;
   public arguments: any = {};
+  public retryCount = 0;
 
   constructor(
     public ctrService: CtrService,
@@ -109,6 +110,12 @@ export class GuacTerminalComponent implements OnChanges {
       console.error(`Tunnel failed ${JSON.stringify(status)}`);
       this.shellService.setStatus(this.vmname, 'Tunnel Error');
       this.connectionState = states.TUNNEL_ERROR;
+      if(this.retryCount < 4) {
+        ++this.retryCount
+        setTimeout(() => {
+          this.reloadConnection()
+        }, 250)
+      }
     };
     tunnel.onstatechange = (state: Tunnel.State) => {
       switch (state) {
@@ -146,6 +153,7 @@ export class GuacTerminalComponent implements OnChanges {
           this.shellService.setStatus(this.vmname, 'Waiting...');
           break;
         case 3:
+          this.retryCount = 0;
           this.connectionState = states.CONNECTED;
           this.shellService.setStatus(this.vmname, 'Connected');
           window.addEventListener('resize', () => {

--- a/src/app/scenario/guacTerminal.component.ts
+++ b/src/app/scenario/guacTerminal.component.ts
@@ -54,6 +54,7 @@ export class GuacTerminalComponent implements OnChanges {
   public errorMessage?: string;
   public arguments: any = {};
   public retryCount = 0;
+  public retryDelays: number[] = [0, 100, 1000, 5000];
 
   constructor(
     public ctrService: CtrService,
@@ -111,10 +112,10 @@ export class GuacTerminalComponent implements OnChanges {
       this.shellService.setStatus(this.vmname, 'Tunnel Error');
       this.connectionState = states.TUNNEL_ERROR;
       if(this.retryCount < 4) {
-        ++this.retryCount
         setTimeout(() => {
           this.reloadConnection()
-        }, 250)
+        }, this.retryDelays[this.retryCount])
+        ++this.retryCount
       }
     };
     tunnel.onstatechange = (state: Tunnel.State) => {

--- a/src/app/scenario/guacTerminal.component.ts
+++ b/src/app/scenario/guacTerminal.component.ts
@@ -53,8 +53,8 @@ export class GuacTerminalComponent implements OnChanges {
   public connectionState = states.IDLE;
   public errorMessage?: string;
   public arguments: any = {};
-  public retryCount = 0;
-  public retryDelays: number[] = [0, 100, 1000, 5000];
+  private retryCount = 0;
+  private scalingDuration = 1000;
 
   constructor(
     public ctrService: CtrService,
@@ -111,11 +111,11 @@ export class GuacTerminalComponent implements OnChanges {
       console.error(`Tunnel failed ${JSON.stringify(status)}`);
       this.shellService.setStatus(this.vmname, 'Tunnel Error');
       this.connectionState = states.TUNNEL_ERROR;
-      if (this.retryCount < 4) {
+      if (this.retryCount < 7) {
+        ++this.retryCount;
         setTimeout(() => {
           this.reloadConnection();
-        }, this.retryDelays[this.retryCount]);
-        ++this.retryCount;
+        }, this.retryCount * this.scalingDuration);
       }
     };
     tunnel.onstatechange = (state: Tunnel.State) => {

--- a/src/app/scenario/guacTerminal.component.ts
+++ b/src/app/scenario/guacTerminal.component.ts
@@ -111,11 +111,11 @@ export class GuacTerminalComponent implements OnChanges {
       console.error(`Tunnel failed ${JSON.stringify(status)}`);
       this.shellService.setStatus(this.vmname, 'Tunnel Error');
       this.connectionState = states.TUNNEL_ERROR;
-      if(this.retryCount < 4) {
+      if (this.retryCount < 4) {
         setTimeout(() => {
-          this.reloadConnection()
-        }, this.retryDelays[this.retryCount])
-        ++this.retryCount
+          this.reloadConnection();
+        }, this.retryDelays[this.retryCount]);
+        ++this.retryCount;
       }
     };
     tunnel.onstatechange = (state: Tunnel.State) => {

--- a/src/app/scenario/guacTerminal.component.ts
+++ b/src/app/scenario/guacTerminal.component.ts
@@ -53,8 +53,7 @@ export class GuacTerminalComponent implements OnChanges {
   public connectionState = states.IDLE;
   public errorMessage?: string;
   public arguments: any = {};
-  private tunnelRetryCount = 0;
-  private clientRetryCount = 0;
+  private retryCount = 0;
   private scalingDuration = 1000;
 
   constructor(
@@ -112,11 +111,11 @@ export class GuacTerminalComponent implements OnChanges {
       console.error(`Tunnel failed ${JSON.stringify(status)}`);
       this.shellService.setStatus(this.vmname, 'Tunnel Error');
       this.connectionState = states.TUNNEL_ERROR;
-      if (this.tunnelRetryCount < 7) {
-        ++this.tunnelRetryCount;
+      if (this.retryCount < 7) {
+        ++this.retryCount;
         setTimeout(() => {
           this.reloadConnection();
-        }, this.tunnelRetryCount * this.scalingDuration);
+        }, this.retryCount * this.scalingDuration);
       }
     };
     tunnel.onstatechange = (state: Tunnel.State) => {
@@ -155,8 +154,7 @@ export class GuacTerminalComponent implements OnChanges {
           this.shellService.setStatus(this.vmname, 'Waiting...');
           break;
         case 3:
-          this.tunnelRetryCount = 0;
-          this.clientRetryCount = 0;
+          this.retryCount = 0;
           this.connectionState = states.CONNECTED;
           this.shellService.setStatus(this.vmname, 'Connected');
           window.addEventListener('resize', () => {
@@ -184,13 +182,6 @@ export class GuacTerminalComponent implements OnChanges {
       this.shellService.setStatus(this.vmname, 'Client Error');
       this.errorMessage = error.message;
       this.connectionState = states.CLIENT_ERROR;
-      if (this.clientRetryCount < 7) {
-        ++this.clientRetryCount;
-        setTimeout(() => {
-          this.shellService.setStatus(this.vmname, 'Reconnecting');
-          this.connect();
-        }, this.clientRetryCount * this.scalingDuration);
-      }
     };
     this.client.onsync = null;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR suggests a simple automatic reload mechanism on tunnel errors.

During a test run on Windows scenarios, we had some tunnel errors which were frequently occuring. It would be nice if the client would at least try a few reconnects automatically so that the user does not need to reload the tab manually.

This PR is in draft mode because we need to clarify the following things:
- should we also implement a retry logic for client connection errors?
- which interval(s) should we choose for our retry logic?