### PR TITLE
Fix home for courses with less scenarios, refactor utf8 decoding

### DIFF
--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -104,7 +104,10 @@
       </div>
     </ng-container>
 
-    <div class="clr-row" *ngIf="courses.length > 0 && ctx.valid">
+    <div
+      class="clr-row course-container"
+      *ngIf="courses.length > 0 && ctx.valid"
+    >
       <div class="clr-col-12">
         <ng-container *ngFor="let c of courses">
           <h3 class="course-header">{{ c.name | atob }}</h3>

--- a/src/app/home.component.scss
+++ b/src/app/home.component.scss
@@ -13,3 +13,7 @@
 cds-icon[shape='clock'] {
   color: black;
 }
+
+.course-container {
+  width: 100%;
+}

--- a/src/app/services/verification.service.ts
+++ b/src/app/services/verification.service.ts
@@ -10,6 +10,7 @@ import { BehaviorSubject, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { VMService } from './vm.service';
+import { atou } from '../unicode';
 
 @Injectable()
 export class VerificationService {
@@ -98,7 +99,7 @@ export class VerificationService {
 
   private publishNewVerificationResults(response: ServerResponse) {
     const newVerificationList = JSON.parse(
-      decodeResponse(response.content),
+      atou(response.content),
     ) as unknown as TaskVerificationResponse[];
     newVerificationList.forEach(
       (newTaskVerification: TaskVerificationResponse) => {
@@ -119,15 +120,4 @@ export class VerificationService {
     );
     this._verifications.next(this._verifications.value);
   }
-}
-
-function decodeResponse(responseContent: string) {
-  const text = atob(responseContent);
-  const length = text.length;
-  const bytes = new Uint8Array(length);
-  for (let i = 0; i < length; i++) {
-    bytes[i] = text.charCodeAt(i);
-  }
-  const decoder = new TextDecoder(); // default is utf-8
-  return decoder.decode(bytes);
 }

--- a/src/app/unicode.ts
+++ b/src/app/unicode.ts
@@ -1,5 +1,12 @@
 export function atou(b64: string) {
-  return decodeURIComponent(escape(atob(b64)));
+  const text = atob(b64);
+  const length = text.length;
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = text.charCodeAt(i);
+  }
+  const decoder = new TextDecoder(); // default is utf-8
+  return decoder.decode(bytes);
 }
 
 export function utoa(data: string) {


### PR DESCRIPTION
Fixes Home screen not showing scenario-tiles in a proper way if they are part of a course containing only 1 to 3 (depending on the size of the screen) scenarios. 

Also refactors the extra utf-8 decoding for tasks to be used for all decoding.