### PR TITLE
Switch guacamole-common-js reference to hobbyfarm-org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "angular-split": "^17.2.0",
-        "guacamole-common-js": "npm:@philipab/guacamole-common@^1.5.5",
+        "guacamole-common-js": "npm:@hobbyfarm-org/guacamole-common-js@^1.5.5",
         "marked": "^12.0.2",
         "mermaid": "^10.6.0",
         "ngx-dynamic-hooks": "^3.1.1",
@@ -9449,10 +9449,10 @@
       "dev": true
     },
     "node_modules/guacamole-common-js": {
-      "name": "@philipab/guacamole-common",
+      "name": "@hobbyfarm-org/guacamole-common-js",
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@philipab/guacamole-common/-/guacamole-common-1.5.5.tgz",
-      "integrity": "sha512-HjyZSLnN54DTetWLJwfTLB85dULpTmmZdlaqSOQc+uOHS8oYRwNxWHCdCROtO7xQLeMNsr5dDMveWLiptx56XA==",
+      "resolved": "https://registry.npmjs.org/@hobbyfarm-org/guacamole-common-js/-/guacamole-common-js-1.5.5.tgz",
+      "integrity": "sha512-GNfSPIWpDKRj155V+zoGZ9SkEj+0I9kJ/Fojz6iaWdXb0O8mjHROMAxsZTZAexFwgO29z9lgl7jOJ/+ROI62gA==",
       "license": "Apache-2.0"
     },
     "node_modules/handle-thing": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "angular-split": "^17.2.0",
-    "guacamole-common-js": "npm:@philipab/guacamole-common@^1.5.5",
+    "guacamole-common-js": "npm:@hobbyfarm-org/guacamole-common-js@^1.5.5",
     "marked": "^12.0.2",
     "mermaid": "^10.6.0",
     "ngx-dynamic-hooks": "^3.1.1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Before, the guacamole-common-js dependency was resolved to my personal npm package. Now it is reflecting the `hobbyfarm-org` release instead.