### PR TITLE
fix: course view, keepVM with content only scenarios

### DIFF
--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -402,7 +402,7 @@ export class StepComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public goFinish() {
     if (this.isContentOnly) {
-      this.actuallyFinish(true);
+      this.actuallyFinish();
       return;
     }
     this.finishOpen = true;


### PR DESCRIPTION
Course View used takeUntilDestroyed outside an injection context. Refactored to not use takeUntilDestroyed. 
Content Only Scenarios now do respect if the VM for a course should be kept on Finish