### PR TITLE
Add Setting to adjust zoom/scaling for Windows VMs

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -242,7 +242,11 @@
     </div>
   </clr-modal>
 
-  <clr-modal #settingsmodal [(clrModalOpen)]="settingsModalOpened">
+  <clr-modal
+    #settingsmodal
+    [(clrModalOpen)]="settingsModalOpened"
+    clrModalSize="lg"
+  >
     <h3 class="modal-title">Settings</h3>
     <div class="modal-body">
       @if (fetchingSettings) {
@@ -581,6 +585,44 @@
                     />
                   </clr-checkbox-wrapper>
                 </clr-checkbox-container>
+              </clr-tab-content>
+              <clr-tab-content> </clr-tab-content>
+            </clr-tab>
+            <clr-tab>
+              <button clrTabLink>Windows Zoom</button>
+              <clr-tab-content>
+                <clr-select-container>
+                  <label
+                    >Zoom
+                    <clr-tooltip>
+                      <cds-icon
+                        clrTooltipTrigger
+                        shape="info-circle"
+                        size="24"
+                      ></cds-icon>
+                      <clr-tooltip-content
+                        [clrPosition]="'top-right'"
+                        [clrSize]="'sm'"
+                      >
+                        Set the Zoom level for Windows VMs.
+                      </clr-tooltip-content>
+                    </clr-tooltip>
+                  </label>
+                  <select
+                    clrSelect
+                    name="options"
+                    formControlName="windowsZoom"
+                  >
+                    @for (value of zoomValues; track value) {
+                      <option value="{{ value }}">
+                        {{ value }}%
+                        @if (isCurrentSystemZoom(value)) {
+                          (same as your Operating System)
+                        }
+                      </option>
+                    }
+                  </select>
+                </clr-select-container>
               </clr-tab-content>
               <clr-tab-content> </clr-tab-content>
             </clr-tab>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { UserService } from './services/user.service';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ServerResponse } from './ServerResponse';
 import { AppConfigService } from './app-config.service';
-import { SettingsService } from './services/settings.service';
+import { SettingsService, WindowsZoom } from './services/settings.service';
 import { themes } from './scenario/terminal-themes/themes';
 import { first } from 'rxjs/operators';
 import { Context, ContextService } from './services/context.service';
@@ -89,6 +89,8 @@ export class AppComponent implements OnInit, OnDestroy {
   public themes = themes;
   public motd = '';
 
+  protected readonly zoomValues = Object.keys(WindowsZoom);
+
   emailSubscription?: Subscription;
 
   constructor(
@@ -163,6 +165,7 @@ export class AppComponent implements OnInit, OnDestroy {
       Validators.required,
     ]),
     bashbrawl_enabled: new FormControl<boolean>(false),
+    windowsZoom: new FormControl<keyof typeof WindowsZoom>('100'),
   });
 
   ngOnInit() {
@@ -271,6 +274,7 @@ export class AppComponent implements OnInit, OnDestroy {
           theme = 'system',
           divider_position = 40,
           bashbrawl_enabled = false,
+          windowsZoom = '100',
         }) => {
           this.settingsForm.setValue({
             terminal_theme,
@@ -279,6 +283,7 @@ export class AppComponent implements OnInit, OnDestroy {
             theme,
             divider_position,
             bashbrawl_enabled,
+            windowsZoom,
           });
           this.fetchingSettings = false;
         },
@@ -449,5 +454,9 @@ export class AppComponent implements OnInit, OnDestroy {
         );
       },
     });
+  }
+
+  isCurrentSystemZoom(windowZoom: string): boolean {
+    return (window.devicePixelRatio * 100).toString() == windowZoom;
   }
 }

--- a/src/app/scenario/guacTerminal.component.ts
+++ b/src/app/scenario/guacTerminal.component.ts
@@ -5,6 +5,7 @@ import {
   Input,
   OnChanges,
   ViewEncapsulation,
+  OnInit,
 } from '@angular/core';
 import { CtrService } from './ctr.service';
 import { CodeExec } from './CodeExec';
@@ -25,6 +26,11 @@ import clipboard from './guacLibs/GuacClipboard';
 import states from './guacLibs/states';
 import { ClipboardCache } from './guacLibs/ClipboardCache';
 import { Mimetype } from 'guacamole-common-js/lib/GuacCommon';
+import {
+  Settings,
+  SettingsService,
+  WindowsZoom,
+} from '../services/settings.service';
 //import {Modal} from '@/components/Modal'
 
 @Component({
@@ -33,7 +39,7 @@ import { Mimetype } from 'guacamole-common-js/lib/GuacCommon';
   styleUrls: ['guacTerminal.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class GuacTerminalComponent implements OnChanges {
+export class GuacTerminalComponent implements OnInit, OnChanges {
   @Input()
   vmid: string;
 
@@ -45,6 +51,7 @@ export class GuacTerminalComponent implements OnChanges {
 
   public optimalWidth = 1024;
   public optimalHeight = 744;
+  private zoom = window.devicePixelRatio;
 
   public connected = false;
   public display: any;
@@ -61,10 +68,24 @@ export class GuacTerminalComponent implements OnChanges {
     public ctrService: CtrService,
     public shellService: ShellService,
     public jwtHelper: JwtHelperService,
+    private settingsService: SettingsService,
   ) {}
 
   @ViewChild('guacTerminal', { static: true }) terminalDiv: ElementRef;
   @ViewChild('viewport', { static: true }) viewport: ElementRef;
+
+  async ngOnInit() {
+    this.settingsService.settings$.subscribe((settings: Settings) => {
+      if (settings.windowsZoom) {
+        this.zoom = WindowsZoom[settings.windowsZoom];
+        setTimeout(() => {
+          this.resize();
+        }, 1000);
+      } else {
+        this.zoom = window.devicePixelRatio;
+      }
+    });
+  }
 
   queryObj() {
     // we always load our token synchronously from local storage
@@ -375,10 +396,8 @@ export class GuacTerminalComponent implements OnChanges {
       // resize is being called on the hidden window
       return;
     }
-    const pixelDensity = window.devicePixelRatio || 1; // window.devicePixelRatio is a floating number
-    const width = Math.floor(elm.clientWidth * pixelDensity);
-    const height = Math.floor(elm.clientHeight * pixelDensity);
-
+    const width = Math.floor(elm.clientWidth * this.zoom);
+    const height = Math.floor(elm.clientHeight * this.zoom);
     return { width: width, height: height };
   }
 

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -15,6 +15,21 @@ import {
   GargantuaClientFactory,
 } from './gargantua.service';
 
+export const WindowsZoom = {
+  '100': 4,
+  '125': 3.75,
+  '150': 3.5,
+  '175': 3.25,
+  '200': 3,
+  '225': 2.75,
+  '250': 2.5,
+  '275': 2.25,
+  '300': 2,
+  '325': 1.75,
+  '350': 1.5,
+  '375': 1.25,
+  '400': 1,
+} as const;
 export interface Settings {
   terminal_theme: (typeof themes)[number]['id'];
   terminal_fontSize: number;
@@ -23,8 +38,8 @@ export interface Settings {
   theme: 'light' | 'dark' | 'system';
   divider_position: number;
   bashbrawl_enabled: boolean;
+  windowsZoom?: keyof typeof WindowsZoom;
 }
-
 @Injectable()
 export class SettingsService {
   constructor(private gcf: GargantuaClientFactory) {}
@@ -47,6 +62,7 @@ export class SettingsService {
               theme: 'system',
               divider_position: 40,
               bashbrawl_enabled: false,
+              windowsZoom: (window.devicePixelRatio * 100).toString(),
             } as Settings),
       ),
       tap((s: Settings) => {


### PR DESCRIPTION
Allows users to Adjust the scaling of UI Elements in Windows VMs via a Setting. Fixes the Problem of too small UI Elements in the Windows VM if the User has a small screen with a high resolution.