### PR TITLE
Quiz - Add linebreaks and rename "Reset"-Button to "Retry"-Button

### DIFF
--- a/src/app/quiz/quiz-label.component.html
+++ b/src/app/quiz/quiz-label.component.html
@@ -1,12 +1,25 @@
 <span
+  class="label-content"
   [ngClass]="{
     'correct-option': hasCorrectOptionClass,
     'incorrect-option': hasIncorrectOptionClass,
   }"
-  >{{ optionTitle }}</span
 >
-@if (hasCorrectOptionClass) {
-  <cds-icon shape="success-standard" status="success" solid="true"></cds-icon>
-} @else if (hasIncorrectOptionClass) {
-  <cds-icon shape="exclamation-circle" status="danger" solid="true"></cds-icon>
-}
+  <span class="option-text">{{ optionTitle }}</span>
+
+  @if (hasCorrectOptionClass) {
+    <cds-icon
+      class="option-icon"
+      shape="success-standard"
+      status="success"
+      solid="true"
+    ></cds-icon>
+  } @else if (hasIncorrectOptionClass) {
+    <cds-icon
+      class="option-icon"
+      shape="exclamation-circle"
+      status="danger"
+      solid="true"
+    ></cds-icon>
+  }
+</span>

--- a/src/app/quiz/quiz-label.component.scss
+++ b/src/app/quiz/quiz-label.component.scss
@@ -1,3 +1,17 @@
+span.label-content {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  max-width: 100%;
+}
+
+span.option-text {
+  /* Normal wrapping between words */
+  white-space: normal;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
 span.correct-option {
   color: var(--clr-alert-success-font-color, hsl(198, 0%, 40%));
   background-color: var(--clr-alert-success-bg-color, hsl(93, 52%, 88%));
@@ -7,4 +21,8 @@ span.correct-option {
 span.incorrect-option {
   color: var(--clr-alert-danger-font-color, hsl(198, 0%, 40%));
   background-color: var(--clr-alert-danger-bg-color, hsl(9, 95%, 92%));
+}
+
+.option-icon {
+  flex: 0 0 auto; /* don't stretch */
 }

--- a/src/app/quiz/quiz.component.html
+++ b/src/app/quiz/quiz.component.html
@@ -82,7 +82,7 @@
         class="btn btn-outline reset-button"
         (click)="reset()"
       >
-        Reset
+        Retry
       </button>
     </div>
     @if(allowedAtts <= 100) {


### PR DESCRIPTION
**What this PR does / why we need it:**
- Renames Quiz `Reset`-Button to `Retry`-Button, to clarify it does **not** reset the selection state but issues a new quiz attempt
- Enables line breaks for long answer options for an enhanced user experience

Example:
<img width="645" height="522" alt="image" src="https://github.com/user-attachments/assets/a75d4c11-39cd-400d-914e-fc1dfee55b64" />
